### PR TITLE
increase timeout to 10 seconds for folks behind VPNs

### DIFF
--- a/api/query.go
+++ b/api/query.go
@@ -35,6 +35,6 @@ func Query(input Input) (res *http.Response, err error) {
 	}
 	req.Header.Add("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: time.Second * 5}
+	client := &http.Client{Timeout: time.Second * 10}
 	return client.Do(req)
 }


### PR DESCRIPTION
Go wasn't able to complete the post request to the runpod server. 5 second was just too short a time. I increased it to 10 seconds and the request goes through.