### PR TITLE
feat: Adds brew install method

### DIFF
--- a/.github/workflows/brew.yml
+++ b/.github/workflows/brew.yml
@@ -1,0 +1,33 @@
+name: goreleaser
+
+on:
+  push:
+    branches:
+      - main
+      - brew-release
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.17
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 bin/
 main
 .vscode/
+vendor/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,32 @@
+builds:
+  - binary: runpod
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -mod=mod
+
+release:
+  prerelease: auto
+
+universal_binaries:
+  - replace: true
+
+brews:
+  -
+    name: runpod
+    homepage: "https://github.com/runpod/runpodctl"
+    repository:
+      owner: runpod
+      name: homebrew-runpod
+    commit_author:
+      name: rachfop
+      email: prachford@icloud.com
+
+checksum:
+  name_template: 'checksums.txt'


### PR DESCRIPTION
Uses this tap: https://github.com/runpod/homebrew-runpod to store brew files.

Updates on every tag released. For example:

```
git add .
git commit -m "Add colored texted"
git push
git tag -a v0.4 -m "Color text feature"
git push origin v0.4
```

And the .4 version of the CLI is now installed on the tap.

To install:

```
# step 1: tap
brew tap runpod/runpod
# step 2: install
brew install runpod
```

Some one with permissions should check that the `GITHUB_TOKEN: ${{ github.token }}` is set up correctly.