### PR TITLE
Updates brew on every tag

### DIFF
--- a/.github/workflows/brew.yml
+++ b/.github/workflows/brew.yml
@@ -2,9 +2,8 @@ name: goreleaser
 
 on:
   push:
-    branches:
-      - main
-      - brew-release
+    tags:
+      - '*'
 
 permissions:
   contents: write


### PR DESCRIPTION
Fix workflow trigger to run on tag push

This commit adjusts the GitHub Actions workflow to trigger on tag pushes instead of branch updates. Previously, the workflow was configured to run only on pushes to the main and brew-release branches, which could lead to issues when releasing new versions that require tagging. 

By modifying the trigger to activate on any tag push, we ensure that the release process via GoReleaser is correctly initiated whenever a new tag is created, aligning the CI/CD process with our versioning and release strategy.