### PR TITLE
Enabled support for creating pods with networkVolumeId

### DIFF
--- a/cmd/pod/createPod.go
+++ b/cmd/pod/createPod.go
@@ -26,6 +26,7 @@ var (
 	templateId        string
 	volumeInGb        int
 	volumeMountPath   string
+	networkVolumeId   string
 )
 
 var CreatePodCmd = &cobra.Command{
@@ -47,6 +48,7 @@ var CreatePodCmd = &cobra.Command{
 			TemplateId:        templateId,
 			VolumeInGb:        volumeInGb,
 			VolumeMountPath:   volumeMountPath,
+			NetworkVolumeId:   networkVolumeId,
 		}
 		if len(ports) > 0 {
 			input.Ports = strings.Join(ports, ",")
@@ -93,6 +95,7 @@ func init() {
 	CreatePodCmd.Flags().StringVar(&templateId, "templateId", "", "templateId to use with the pod")
 	CreatePodCmd.Flags().IntVar(&volumeInGb, "volumeSize", 1, "persistent volume disk size in GB")
 	CreatePodCmd.Flags().StringVar(&volumeMountPath, "volumePath", "/runpod", "container volume path")
+	CreatePodCmd.Flags().StringVar(&networkVolumeId, "networkVolumeId", "", "network volume id")
 
 	CreatePodCmd.MarkFlagRequired("gpuType")   //nolint
 	CreatePodCmd.MarkFlagRequired("imageName") //nolint

--- a/docs/runpodctl_create_pod.md
+++ b/docs/runpodctl_create_pod.md
@@ -30,6 +30,7 @@ runpodctl create pod [flags]
       --vcpu int                minimum vCPUs needed (default 1)
       --volumePath string       container volume path (default "/runpod")
       --volumeSize int          persistent volume disk size in GB (default 1)
+      --networkVolumeId string  network volume id
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
# Enabled support for creating pods with networkVolumeId 

You can now create pods with --networkVolumeId flag.

## Example usage:
`runpodctl create pod --imageName "XXXX"  --templateId "XXXX" --gpuType "NVIDIA GeForce RTX 4090" --networkVolumeId "XXXX" --volumePath "/workspace"`


## Related:
- #94: Create Pod with Network Volume Attached 

