### PR TITLE
fix: remove trailing newline from version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: build
         run: |
           export CGO_ENABLED=0
-          echo "${{ steps.release.outputs.tag_name }}" > version 
+          echo "${{ steps.release.outputs.tag_name }}" | tr -d '\n' > version 
           env GOOS=android GOARCH=arm64 go build -o bin/runpodctl-android-arm64 .
           env GOOS=darwin GOARCH=amd64 go build -o bin/runpodctl-darwin-amd64 .
           env GOOS=darwin GOARCH=arm64 go build -o bin/runpodctl-darwin-arm64 .
@@ -103,4 +103,3 @@ jobs:
           args: release --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}
-          VERSION: ${{ steps.release.outputs.tag_name }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,3 @@
-before:
-  hooks:
-    - echo "{{ .Env.VERSION }}" > version
-
 builds:
   - binary: runpodctl
     goos:


### PR DESCRIPTION
version is correctly being populated in both build script and goreleaser, but it has a trailing newline. This causes an error when including the version in the User-Agent string which breaks every http request (runpodctl get pod etc)