### PR TITLE
E-951: new command `scp-help`: teaches people how to use scp

### DIFF
--- a/cmd/croc/croc.go
+++ b/cmd/croc/croc.go
@@ -449,7 +449,7 @@ func (c *Client) setupLocalRelay() {
 
 func (c *Client) broadcastOnLocalNetwork(useipv6 bool) {
 	var timeLimit time.Duration
-	//if we don't use an external relay, the broadcast messages need to be sent continuously
+	// if we don't use an external relay, the broadcast messages need to be sent continuously
 	if c.Options.OnlyLocal {
 		timeLimit = -1 * time.Second
 	} else {
@@ -515,7 +515,6 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 	c.TotalNumberFolders = totalNumberFolders
 	c.TotalNumberOfContents = len(filesInfo)
 	err = c.sendCollectFiles(filesInfo)
-
 	if err != nil {
 		return
 	}
@@ -1120,7 +1119,7 @@ func (c *Client) processMessagePake(m message.Message) (err error) {
 			Type:   message.TypePAKE,
 			Bytes:  c.Pake.Bytes(),
 			Bytes2: salt,
-		})
+		}) // TODO: check me
 	} else {
 		err = c.Pake.Update(m.Bytes)
 		if err != nil {
@@ -1350,7 +1349,7 @@ func (c *Client) recipientInitializeFile() (err error) {
 	var errOpen error
 	c.CurrentFile, errOpen = os.OpenFile(
 		pathToFile,
-		os.O_WRONLY, 0666)
+		os.O_WRONLY, 0o666)
 	var truncate bool // default false
 	c.CurrentFileChunks = []int64{}
 	c.CurrentFileChunkRanges = []int64{}

--- a/cmd/croc/send-ssh.go
+++ b/cmd/croc/send-ssh.go
@@ -1,0 +1,62 @@
+package croc
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const scpHelp = `
+----Summary----
+The built-in scp command, available as part of the POSIX standard, can be used to securely copy files between your local machine
+and a runpod instance you already have SSH access to.
+
+This is not part of runpodctl - we provide this documentation for your convenience only.
+
+Linux, MacOS, and Windows 10 all come with scp pre-installed.
+
+--- Quick Start -----
+The following quick-start guide: obtained via the tldr.sh project under the MIT license, provides a brief overview of how to use scp. https://tldr.sh/
+
+Secure copy.
+Copy files between hosts using Secure Copy Protocol over SSH.
+More information: <https://man.openbsd.org/scp>.
+
+Copy a local file to a remote host:
+
+	scp path/to/local_file remote_host:path/to/remote_file
+
+Use a specific port when connecting to the remote host:
+
+	scp -P port path/to/local_file remote_host:path/to/remote_file
+
+Copy a file from a remote host to a local directory:
+
+	scp remote_host:path/to/remote_file path/to/local_directory
+
+Recursively copy the contents of a directory from a remote host to a local directory:
+
+	scp -r remote_host:path/to/remote_directory path/to/local_directory
+
+Copy a file between two remote hosts transferring through the local host:
+
+	scp -3 host1:path/to/remote_file host2:path/to/remote_directory
+
+Use a specific username when connecting to the remote host:
+
+	scp path/to/local_file remote_username@remote_host:path/to/remote_directory
+
+Use a specific SSH private key for authentication with the remote host:
+
+	scp -i ~/.ssh/private_key path/to/local_file remote_host:path/to/remote_file
+
+Use a specific proxy when connecting to the remote host:
+
+	scp -J proxy_username@proxy_host path/to/local_file remote_host:path/to/remote_file`
+
+var SCPHelp = &cobra.Command{
+	Use:   "scp-help",
+	Short: "help for using scp (secure copy over SSH)",
+	Args:  cobra.NoArgs,
+	Run:   func(cmd *cobra.Command, args []string) { fmt.Println(scpHelp) },
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,7 @@ func registerCommands() {
 	// file transfer via croc
 	rootCmd.AddCommand(croc.ReceiveCmd)
 	rootCmd.AddCommand(croc.SendCmd)
+	rootCmd.AddCommand(croc.SCPHelp)
 
 	// Version
 	rootCmd.Version = version


### PR DESCRIPTION
# E-951 - teach people how to use SCP

Add new command, `scp-help`, which teaches users how to use SCP. Since it will show up in the command list, that should make this behavior more discoverable.

I also slightly cleaned up `send` and `receive` so that they don't fail with index-out-of-range errors and added an (extremely generous) timeout for for looking up the relays so it doesn't just hang forever.

## How I tested it
Nothing to test.