### PR TITLE
feat and fix: add gpuCount argument to StartSpotPod

### DIFF
--- a/api/pod.go
+++ b/api/pod.go
@@ -355,11 +355,11 @@ func StartOnDemandPod(id string) (pod map[string]interface{}, err error) {
 	return
 }
 
-func StartSpotPod(id string, bidPerGpu float32) (podBidResume map[string]interface{}, err error) {
+func StartSpotPod(id string, bidPerGpu float32, gpuCount int) (podBidResume map[string]interface{}, err error) {
 	input := Input{
 		Query: `
 		mutation Mutation($podId: String!, $bidPerGpu: Float!) {
-			podBidResume(input: {podId: $podId, bidPerGpu: $bidPerGpu}) {
+			podBidResume(input: {podId: $podId, bidPerGpu: $bidPerGpu, gpuCount: $gpuCount}) {
 			  id
 			  costPerHr
 			  desiredStatus
@@ -367,7 +367,7 @@ func StartSpotPod(id string, bidPerGpu float32) (podBidResume map[string]interfa
 			}
 		}
 		`,
-		Variables: map[string]interface{}{"podId": id, "bidPerGpu": bidPerGpu},
+		Variables: map[string]interface{}{"podId": id, "bidPerGpu": bidPerGpu, "gpuCount": gpuCount},
 	}
 	res, err := Query(input)
 	if err != nil {

--- a/cmd/pod/startPod.go
+++ b/cmd/pod/startPod.go
@@ -9,6 +9,7 @@ import (
 )
 
 var bidPerGpu float32
+var gpuCount int
 
 var StartPodCmd = &cobra.Command{
 	Use:   "pod [podId]",
@@ -19,7 +20,7 @@ var StartPodCmd = &cobra.Command{
 		var err error
 		var pod map[string]interface{}
 		if bidPerGpu > 0 {
-			pod, err = api.StartSpotPod(args[0], bidPerGpu)
+			pod, err = api.StartSpotPod(args[0], bidPerGpu, gpuCount)
 		} else {
 			pod, err = api.StartOnDemandPod(args[0])
 		}
@@ -36,4 +37,5 @@ var StartPodCmd = &cobra.Command{
 
 func init() {
 	StartPodCmd.Flags().Float32Var(&bidPerGpu, "bid", 0, "bid per gpu for spot price")
+	StartPodCmd.Flags().IntVar(&gpuCount, "gpuCount", 1, "number of GPUs to request")
 }


### PR DESCRIPTION
# Add gpuCount argument

## Related:
- #156: can't start spot pod using the cli 

## Description

The start StartSpotPod endpoint is missing the gpuCount argument, causing it to not work at all. I added the argument to the ctl, and the corresponding graphQL call.

## How I tested it

I run the graphQL query by hand with and without the argument I added. Without it, I get back a 400 error, and with it everything works great.