### PR TITLE
E-1654: fix: only add key when not exist in db.

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"os"
+	"strings"
 
 	"github.com/runpod/runpodctl/api"
 	"github.com/runpod/runpodctl/cmd/ssh"
@@ -21,25 +21,78 @@ var ConfigCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Manage CLI configuration",
 	Long:  "RunPod CLI Config Settings",
-	Run: func(c *cobra.Command, args []string) {
-		if err := viper.WriteConfig(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
-			return
+	RunE: func(c *cobra.Command, args []string) error {
+		if err := saveConfig(); err != nil {
+			return fmt.Errorf("error saving config: %w", err)
 		}
-		fmt.Println("Configuration saved to file:", viper.ConfigFileUsed())
 
-		publicKey, err := ssh.GenerateSSHKeyPair("RunPod-Key-Go")
+		publicKey, err := getOrCreateSSHKey()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to generate SSH key: %v\n", err)
-			return
+			return fmt.Errorf("failed to get or create local SSH key: %w", err)
 		}
 
-		if err := api.AddPublicSSHKey(publicKey); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to add the SSH key: %v\n", err)
-			return
+		if err := updateSSHKeyInCloud(publicKey); err != nil {
+			return fmt.Errorf("failed to update SSH key in the cloud: %w", err)
 		}
-		fmt.Println("SSH key added successfully.")
+
+		return nil
 	},
+}
+
+// saveConfig saves the CLI configuration to a file
+func saveConfig() error {
+	if err := viper.WriteConfig(); err != nil {
+		return err
+	}
+	fmt.Println("Configuration saved to file:", viper.ConfigFileUsed())
+	return nil
+}
+
+// Checks for an existing local SSH key and generates a new one if not found
+func getOrCreateSSHKey() ([]byte, error) {
+	publicKey, err := ssh.GetLocalSSHKey()
+	if err != nil {
+		return nil, fmt.Errorf("error checking for local SSH key: %w", err)
+	}
+
+	if publicKey == nil {
+		fmt.Println("No existing local SSH key found, generating a new one.")
+		publicKey, err = ssh.GenerateSSHKeyPair("RunPod-Key-Go")
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate SSH key: %w", err)
+		}
+		fmt.Println("New SSH key pair generated.")
+	} else {
+		fmt.Println("Existing local SSH key found.")
+	}
+
+	return publicKey, nil
+}
+
+// Checks if the SSH key exists in the cloud and adds it if necessary
+func updateSSHKeyInCloud(publicKey []byte) error {
+	_, cloudKeys, err := api.GetPublicSSHKeys()
+	if err != nil {
+		return fmt.Errorf("failed to get SSH key in the cloud: %w", err)
+	}
+
+	// Trim any whitespace from the publicKey
+	publicKeyStr := strings.TrimSpace(string(publicKey))
+
+	// Check if the publicKey already exists in the cloud
+	for _, cloudKey := range cloudKeys {
+		if strings.TrimSpace(cloudKey.Key) == publicKeyStr {
+			fmt.Println("SSH key already exists in the cloud. No action needed.")
+			return nil
+		}
+	}
+
+	if err := api.AddPublicSSHKey(publicKey); err != nil {
+		return fmt.Errorf("failed to add the SSH key: %w", err)
+	}
+
+	fmt.Println("SSH key added successfully to the cloud.")
+	return nil
 }
 
 func init() {

--- a/cmd/ssh/functions.go
+++ b/cmd/ssh/functions.go
@@ -63,3 +63,23 @@ func GenerateSSHKeyPair(keyName string) ([]byte, error) {
 	fmt.Printf("SSH key pair generated: %s (private), %s (public)\n", privateKeyPath, publicKeyPath)
 	return publicKeyBytes, nil
 }
+
+func GetLocalSSHKey() ([]byte, error) {
+	usr, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current user: %w", err)
+	}
+
+	keyPath := filepath.Join(usr, ".ssh", "RunPod-Key-Go.pub")
+
+	if _, err := os.Stat(keyPath); os.IsNotExist(err) {
+		return nil, nil // No existing key found
+	}
+
+	publicKey, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read existing public key: %w", err)
+	}
+
+	return publicKey, nil
+}


### PR DESCRIPTION
# E-1654: Only Add Key If It Doesn’t Already Exist in the Database

# Description
Currently, running `runpodctl config --apiKey xxx` creates a new key and appends it to the `pubKey` field each time.

Change: Modify the behavior so that a key is only created if it doesn’t already exist in the database.

# How do I test it?
Build package locally and run command `config --apiKey xxx`