### PR TITLE
feat: add dataCenterId pod create option

### DIFF
--- a/api/pod.go
+++ b/api/pod.go
@@ -34,6 +34,7 @@ type Pod struct {
 	ContainerDiskInGb int
 	CostPerHr         float32
 	DesiredStatus     string
+	DataCenterId      string
 	DockerArgs        string
 	Env               []string
 	GpuCount          int
@@ -140,6 +141,7 @@ type CreatePodInput struct {
 	ContainerDiskInGb int       `json:"containerDiskInGb"`
 	DeployCost        float32   `json:"deployCost,omitempty"`
 	DockerArgs        string    `json:"dockerArgs"`
+	DataCenterId      string    `json:"dataCenterId"`
 	Env               []*PodEnv `json:"env"`
 	GpuCount          int       `json:"gpuCount"`
 	GpuTypeId         string    `json:"gpuTypeId"`

--- a/cmd/pod/createPod.go
+++ b/cmd/pod/createPod.go
@@ -14,6 +14,7 @@ var (
 	secureCloud       bool
 	containerDiskInGb int
 	deployCost        float32
+	dataCenterId      string
 	dockerArgs        string
 	env               []string
 	gpuCount          int
@@ -38,6 +39,7 @@ var CreatePodCmd = &cobra.Command{
 		input := &api.CreatePodInput{
 			ContainerDiskInGb: containerDiskInGb,
 			DeployCost:        deployCost,
+			DataCenterId:      dataCenterId,
 			DockerArgs:        dockerArgs,
 			GpuCount:          gpuCount,
 			GpuTypeId:         gpuTypeId,
@@ -96,6 +98,7 @@ func init() {
 	CreatePodCmd.Flags().IntVar(&volumeInGb, "volumeSize", 1, "persistent volume disk size in GB")
 	CreatePodCmd.Flags().StringVar(&volumeMountPath, "volumePath", "/runpod", "container volume path")
 	CreatePodCmd.Flags().StringVar(&networkVolumeId, "networkVolumeId", "", "network volume id")
+	CreatePodCmd.Flags().StringVar(&dataCenterId, "dataCenterId", "", "datacenter id to create in")
 
 	CreatePodCmd.MarkFlagRequired("gpuType")   //nolint
 	CreatePodCmd.MarkFlagRequired("imageName") //nolint


### PR DESCRIPTION
# E-XXXX: add dataCenterId pod create option
Adds the ability to control the specific datacenter a pod is to be created in.

## How I tested it

1. Used go debugger to ensure the graphql statement was rendered correctly.
2. Built the CLI and ran the following command: `runpodctl create pod --dataCenterId EU-SE-1 --secureCloud --gpuType "NVIDIA A40" --gpuCount 1 --templateId runpod-torch-v21 --imageName runpod/pytorch:2.1.0-py3.10-cuda11.8.0-devel-ubuntu22.04 --name test` 
3. verified that the Pod created was indeed listed as being in the `SE` location using the the runpod WebUI (console): https://www.runpod.io/console/pods (and expand the pod to see the location field).

Closes #158

_PS, no idea what the "E-XXXX" is supposed to be, so let me know and I'll add an appropriate number there._