### PR TITLE
feat: add startSSH pod create option

### DIFF
--- a/cmd/pod/createPod.go
+++ b/cmd/pod/createPod.go
@@ -24,6 +24,7 @@ var (
 	minVcpuCount      int
 	name              string
 	ports             []string
+	startSSH          bool
 	templateId        string
 	volumeInGb        int
 	volumeMountPath   string
@@ -47,6 +48,7 @@ var CreatePodCmd = &cobra.Command{
 			MinMemoryInGb:     minMemoryInGb,
 			MinVcpuCount:      minVcpuCount,
 			Name:              name,
+			StartSSH:          startSSH,
 			TemplateId:        templateId,
 			VolumeInGb:        volumeInGb,
 			VolumeMountPath:   volumeMountPath,
@@ -99,6 +101,7 @@ func init() {
 	CreatePodCmd.Flags().StringVar(&volumeMountPath, "volumePath", "/runpod", "container volume path")
 	CreatePodCmd.Flags().StringVar(&networkVolumeId, "networkVolumeId", "", "network volume id")
 	CreatePodCmd.Flags().StringVar(&dataCenterId, "dataCenterId", "", "datacenter id to create in")
+	CreatePodCmd.Flags().BoolVar(&startSSH, "startSSH", false, "enable SSH login")
 
 	CreatePodCmd.MarkFlagRequired("gpuType")   //nolint
 	CreatePodCmd.MarkFlagRequired("imageName") //nolint


### PR DESCRIPTION
# E-XXXX: Add startSSH pod create option

Adds the ability to start the SSHd server when creating pods, to enable ssh login.

## How I tested it
1. Used go debugger to ensure the graphql statement was rendered correctly.
2. Built the CLI and ran the following command: `runpodctl create pod --startSSH --secureCloud --gpuType "NVIDIA A40" --gpuCount 1 --templateId runpod-torch-v21 --imageName runpod/pytorch:2.1.0-py3.10-cuda11.8.0-devel-ubuntu22.04 --name test`
3. Verified I could login using the ssh command listed in the Runpod Web Console > Connect Options > `SSH over exposed TCP: (Supports SCP & SFTP)`

Relates to #30 

_PS, no idea what the "E-XXXX" is supposed to be, so let me know and I'll add an appropriate number there._