### PR TITLE
feat: add pod location field

### DIFF
--- a/api/pod.go
+++ b/api/pod.go
@@ -50,6 +50,7 @@ type Pod struct {
 }
 type Machine struct {
 	GpuDisplayName string
+	Location       string
 }
 type Runtime struct {
 	Ports []*Ports
@@ -91,6 +92,7 @@ func GetPods() (pods []*Pod, err error) {
 				volumeMountPath
 				machine {
 				  gpuDisplayName
+				  location
 				}
 				runtime {
 				  ports	{

--- a/cmd/pod/getPod.go
+++ b/cmd/pod/getPod.go
@@ -51,6 +51,7 @@ var GetPodCmd = &cobra.Command{
 					fmt.Sprintf("%d", p.MemoryInGb),
 					fmt.Sprintf("%d", p.ContainerDiskInGb),
 					fmt.Sprintf("%d", p.VolumeInGb),
+					fmt.Sprintf("%s", p.Machine.Location),
 					fmt.Sprintf("%.3f", p.CostPerHr),
 					fmt.Sprintf("%s", strings.Join(ports[:], ",")),
 				)
@@ -60,7 +61,7 @@ var GetPodCmd = &cobra.Command{
 
 		header := []string{"ID", "Name", "GPU", "Image Name", "Status"}
 		if AllFields {
-			header = append(header, "Pod Type", "vCPU", "Mem", "Container Disk", "Volume Disk", "$/hr", "Ports")
+			header = append(header, "Pod Type", "vCPU", "Mem", "Container Disk", "Volume Disk", "Location", "$/hr", "Ports")
 		}
 
 		tb := tablewriter.NewWriter(os.Stdout)


### PR DESCRIPTION
# E-XXXX: Add location to pod fields displayed

Adds the pod location as a field when issuing "get pod -a" so users know where a given pod is running.

## How I tested it
1. Built the CLI and ran the following command: `runpodctl get pod -a`
2. Verified the location value was the same as listed in the Runpod Web Console.

Example output:
```
runpodctl.exe get pod -a
ID              NAME    GPU     IMAGE NAME                                                      STATUS  POD TYPE        VCPU    MEM     CONTAINER DISK  VOLUME DISK     LOCATION        $/HR    PORTS                                        
1idtz9noa2ae00  test3   1 A40   runpod/pytorch:2.1.0-py3.10-cuda11.8.0-devel-ubuntu22.04        RUNNING RESERVED        9       50      20              1               CA              0.390   100.65.18.232:60039->19123 (prv,http),69.30.85.55:22128->22 (pub,tcp),100.65.18.232:60040->8888 (prv,http)
```

Closes #166 

_PS, no idea what the "E-XXXX" is supposed to be, so let me know and I'll add an appropriate number there._