### PR TITLE
feat: add ssh-connect string subcommand

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -15,4 +15,5 @@ var sshCmd = &cobra.Command{
 func init() {
 	sshCmd.AddCommand(ssh.ListKeysCmd)
 	sshCmd.AddCommand(ssh.AddKeyCmd)
+	sshCmd.AddCommand(ssh.ConnectCmd)
 }


### PR DESCRIPTION
# E-XXXX: Add SSH connect string subcommand

Adds the ability for the ssh subcommand to show the connect string for a given pod, or all of them.

## How I tested it
Interactively; verified the output from the program's main function.

1. For a given pod:
   ```
   go run main.go ssh connect test
   ssh root@213.173.105.91 -p 53006
   ```

2. For a given pod with verbose output:
   ```
   go run main.go ssh connect test --verbose
   ssh root@213.173.105.91 -p 53006  # pod { id: "l6ecafz8g9l2pu", name: "test" }
   ```

3. For a non existing pod
   ```
   go run main.go ssh connect foo
   No pod with id or name "foo" found
   ```

4. For all pods
   ```
   go run main.go ssh connect
   ssh root@213.173.105.83 -p 4498   # pod { id: "evoszzij78cm4u", name: "test2" }
   ssh root@213.173.105.91 -p 53006  # pod { id: "l6ecafz8g9l2pu", name: "test" }
   ```

_note: verbose output makes sense to always show when listing more than one pod, so the user knows which connect string refers to what pod, so that's why >1 pods listed will always provide pod identifying information._

Closes #30 

_PS, no idea what the "E-XXXX" is supposed to be, so let me know and I'll add an appropriate number there._