### PR TITLE
Added globalNetwork as a flag

### DIFF
--- a/api/pod.go
+++ b/api/pod.go
@@ -139,6 +139,7 @@ func GetPods() (pods []*Pod, err error) {
 }
 
 type CreatePodInput struct {
+	GlobalNetwork  bool 		`json:"globalNetwork"`
 	CloudType         string    `json:"cloudType"`
 	ContainerDiskInGb int       `json:"containerDiskInGb"`
 	DeployCost        float32   `json:"deployCost,omitempty"`

--- a/cmd/pod/createPod.go
+++ b/cmd/pod/createPod.go
@@ -85,7 +85,7 @@ var CreatePodCmd = &cobra.Command{
 }
 
 func init() {
-	CreatePodCmd.Flags().BoolVar(&globalNetwork, "globalNetworking", false, "enable global networking if applicable")
+	CreatePodCmd.Flags().BoolVar(&globalNetwork, "globalNetwork", false, "enable global networking (if applicable)")
 	CreatePodCmd.Flags().BoolVar(&communityCloud, "communityCloud", false, "create in community cloud")
 	CreatePodCmd.Flags().BoolVar(&secureCloud, "secureCloud", false, "create in secure cloud")
 	CreatePodCmd.Flags().IntVar(&containerDiskInGb, "containerDiskSize", 20, "container disk size in GB")

--- a/cmd/pod/createPod.go
+++ b/cmd/pod/createPod.go
@@ -10,6 +10,7 @@ import (
 )
 
 var (
+	globalNetwork     bool
 	communityCloud    bool
 	secureCloud       bool
 	containerDiskInGb int
@@ -38,6 +39,7 @@ var CreatePodCmd = &cobra.Command{
 	Long:  "start a pod from runpod.io",
 	Run: func(cmd *cobra.Command, args []string) {
 		input := &api.CreatePodInput{
+			GlobalNetwork: globalNetwork,
 			ContainerDiskInGb: containerDiskInGb,
 			DeployCost:        deployCost,
 			DataCenterId:      dataCenterId,
@@ -83,6 +85,7 @@ var CreatePodCmd = &cobra.Command{
 }
 
 func init() {
+	CreatePodCmd.Flags().BoolVar(&globalNetwork, "globalNetworking", false, "enable global networking if applicable")
 	CreatePodCmd.Flags().BoolVar(&communityCloud, "communityCloud", false, "create in community cloud")
 	CreatePodCmd.Flags().BoolVar(&secureCloud, "secureCloud", false, "create in secure cloud")
 	CreatePodCmd.Flags().IntVar(&containerDiskInGb, "containerDiskSize", 20, "container disk size in GB")


### PR DESCRIPTION
# Added globalNetwork as a flag

This patch adds the `globalNetwork` flag to allow global networking to be enable (when applicable) throught the CLI tool. This was not previously possible and I did not understand why so I just quickly fixed it and thought that someone else might also need this.

(Fix for #190)

## How I tested it
I tested it by creating two pods using the following commands:
```
go run main.go create pod --name "testing" --imageName "runpod/base:0.5.1-cpu" --gpuType "NVIDIA RTX A4000" --startSSH --secureCloud --globalNetwork
go run main.go create pod --name "testing2" --imageName "runpod/base:0.5.1-cpu" --gpuType "NVIDIA RTX A4000" --startSSH --secureCloud --globalNetwork
```
Then testing if the two pods could ping each other as per the global networking [documentation](https://docs.runpod.io/pods/networking)