### PR TITLE
Fix version string and auth header

### DIFF
--- a/api/query.go
+++ b/api/query.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -45,7 +46,8 @@ func Query(input Input) (res *http.Response, err error) {
 		return
 	}
 
-	userAgent := "RunPod-CLI/" + Version + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
+	sanitizedVersion := strings.TrimRight(Version, "\r\n")
+	userAgent := "RunPod-CLI/" + sanitizedVersion + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Set("User-Agent", userAgent)

--- a/api/query.go
+++ b/api/query.go
@@ -41,7 +41,7 @@ func Query(input Input) (res *http.Response, err error) {
 		return nil, errors.New("API key not found")
 	}
 
-	req, err := http.NewRequest("POST", apiUrl+"?api_key="+apiKey, bytes.NewBuffer(jsonValue))
+	req, err := http.NewRequest("POST", apiUrl, bytes.NewBuffer(jsonValue))
 	if err != nil {
 		return
 	}
@@ -51,6 +51,7 @@ func Query(input Input) (res *http.Response, err error) {
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Authorization", "Bearer "+apiKey)
 
 	client := &http.Client{Timeout: time.Second * 10}
 	return client.Do(req)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/runpod/runpodctl/api"
 	"github.com/runpod/runpodctl/cmd/config"
@@ -61,14 +62,19 @@ func registerCommands() {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute(ver string) {
-	version = ver
-	api.Version = ver
-	rootCmd.Version = ver
+	sanitizedVersion := sanitizeVersion(ver)
+	version = sanitizedVersion
+	api.Version = sanitizedVersion
+	rootCmd.Version = sanitizedVersion
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func sanitizeVersion(ver string) string {
+	return strings.TrimRight(ver, "\r\n")
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
# Fix version string and auth header

If the version string ends with a newline it will cause this error: `net/http: invalid header field value for "User-Agent"`
Strip trailing newlines from the version.

Sending the API key via a parameter is deprecated. Send it in an auth header instead.

## How I tested it

Local dev