### PR TITLE
fix: return empty list when template list offset exceeds count

### DIFF
--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -243,7 +243,10 @@ func (c *Client) ListAllTemplates(opts *TemplateListOptions) ([]Template, error)
 
 	// Apply pagination
 	if opts != nil {
-		if opts.Offset > 0 && opts.Offset < len(allTemplates) {
+		if opts.Offset > 0 {
+			if opts.Offset >= len(allTemplates) {
+				return []Template{}, nil
+			}
 			allTemplates = allTemplates[opts.Offset:]
 		}
 		if opts.Limit > 0 && opts.Limit < len(allTemplates) {


### PR DESCRIPTION
## Summary
  - `template list` returned the full unsliced result when `--offset` was greater than or equal to the number of templates after filtering. Pagination check used `opts.Offset < len(allTemplates)`, so out of range offsets fell through and re-returned everything.
  - Fix returns `[]Template{}` immediately when `Offset >= len(allTemplates)`.
## Before fix
  - `runpodctl template list --type official` → 13 templates
  - `runpodctl template list --type official --offset 13` → returned all 13 again (expected `[]`)
  - `runpodctl template list --type official --offset 99999` → returned all 13 (expected `[]`)
## After fix
  - `--offset 13` → `[]`
  - `--offset 99999` → `[]`
  - `--offset 5` → 8 results (in-range still correct)
## Test plan
  - [x] go test ./...
  - [x] go vet ./...
  - [x] live e2e against api.runpod.io for offset edge cases above
  - [ ] go test -tags e2e ./e2e