### PR TITLE
fix: parse serverless networkVolumeIds returned as id strings

### DIFF
--- a/internal/api/endpoints.go
+++ b/internal/api/endpoints.go
@@ -38,6 +38,25 @@ type EndpointNetworkVolume struct {
 	DataCenterID    string `json:"dataCenterId,omitempty"`
 }
 
+// UnmarshalJSON tolerates both shapes of networkVolumeIds: the rest read
+// endpoint returns bare id strings (["vol-1"]) while the graphql saveEndpoint
+// write path uses objects ([{"networkVolumeId":"vol-1"}]).
+func (v *EndpointNetworkVolume) UnmarshalJSON(data []byte) error {
+	var id string
+	if err := json.Unmarshal(data, &id); err == nil {
+		v.NetworkVolumeID = id
+		return nil
+	}
+
+	type alias EndpointNetworkVolume
+	var obj alias
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	*v = EndpointNetworkVolume(obj)
+	return nil
+}
+
 // EndpointListResponse is the response from listing endpoints
 type EndpointListResponse struct {
 	Endpoints []Endpoint `json:"endpoints"`

--- a/internal/api/endpoints_test.go
+++ b/internal/api/endpoints_test.go
@@ -15,10 +15,14 @@ func TestListEndpoints(t *testing.T) {
 		if r.URL.Path != "/endpoints" {
 			t.Errorf("expected /endpoints, got %s", r.URL.Path)
 		}
-		json.NewEncoder(w).Encode([]Endpoint{
-			{ID: "ep-1", Name: "endpoint-1"},
-			{ID: "ep-2", Name: "endpoint-2"},
-		})
+		// serve the raw rest wire shape, not a re-encoded Endpoint struct, so
+		// the test exercises the real api format (networkVolumeIds as bare id
+		// strings) — a struct round-trip would emit the object shape instead
+		// and hide read/write divergences.
+		w.Write([]byte(`[
+			{"id":"ep-1","name":"endpoint-1","networkVolumeIds":["vol-1"]},
+			{"id":"ep-2","name":"endpoint-2"}
+		]`))
 	}))
 	defer server.Close()
 
@@ -33,6 +37,9 @@ func TestListEndpoints(t *testing.T) {
 	}
 	if len(endpoints) != 2 {
 		t.Errorf("expected 2 endpoints, got %d", len(endpoints))
+	}
+	if len(endpoints[0].NetworkVolumeIDs) != 1 || endpoints[0].NetworkVolumeIDs[0].NetworkVolumeID != "vol-1" {
+		t.Errorf("expected vol-1 on first endpoint, got %+v", endpoints[0].NetworkVolumeIDs)
 	}
 }
 
@@ -61,12 +68,16 @@ func TestGetEndpoint(t *testing.T) {
 		if r.URL.Path != "/endpoints/ep-123" {
 			t.Errorf("expected /endpoints/ep-123, got %s", r.URL.Path)
 		}
-		json.NewEncoder(w).Encode(Endpoint{
-			ID:         "ep-123",
-			Name:       "my-endpoint",
-			WorkersMin: 0,
-			WorkersMax: 3,
-		})
+		// raw rest wire shape, including a network volume returned as a bare id
+		// string — this is what regressed serverless get in production.
+		w.Write([]byte(`{
+			"id":"ep-123",
+			"name":"my-endpoint",
+			"workersMin":0,
+			"workersMax":3,
+			"networkVolumeId":"vol-9",
+			"networkVolumeIds":["vol-9"]
+		}`))
 	}))
 	defer server.Close()
 
@@ -81,6 +92,9 @@ func TestGetEndpoint(t *testing.T) {
 	}
 	if endpoint.ID != "ep-123" {
 		t.Errorf("expected ep-123, got %s", endpoint.ID)
+	}
+	if len(endpoint.NetworkVolumeIDs) != 1 || endpoint.NetworkVolumeIDs[0].NetworkVolumeID != "vol-9" {
+		t.Errorf("expected vol-9, got %+v", endpoint.NetworkVolumeIDs)
 	}
 }
 

--- a/internal/api/endpoints_test.go
+++ b/internal/api/endpoints_test.go
@@ -36,6 +36,26 @@ func TestListEndpoints(t *testing.T) {
 	}
 }
 
+func TestEndpointNetworkVolumeIDsUnmarshal(t *testing.T) {
+	// rest read shape: bare id strings.
+	var strShape Endpoint
+	if err := json.Unmarshal([]byte(`{"id":"ep-1","networkVolumeIds":["vol-1","vol-2"]}`), &strShape); err != nil {
+		t.Fatalf("failed to unmarshal string shape: %v", err)
+	}
+	if len(strShape.NetworkVolumeIDs) != 2 || strShape.NetworkVolumeIDs[0].NetworkVolumeID != "vol-1" {
+		t.Fatalf("unexpected string-shape parse: %+v", strShape.NetworkVolumeIDs)
+	}
+
+	// graphql write shape: objects.
+	var objShape Endpoint
+	if err := json.Unmarshal([]byte(`{"id":"ep-2","networkVolumeIds":[{"networkVolumeId":"vol-3","dataCenterId":"US-GA-1"}]}`), &objShape); err != nil {
+		t.Fatalf("failed to unmarshal object shape: %v", err)
+	}
+	if len(objShape.NetworkVolumeIDs) != 1 || objShape.NetworkVolumeIDs[0].NetworkVolumeID != "vol-3" || objShape.NetworkVolumeIDs[0].DataCenterID != "US-GA-1" {
+		t.Fatalf("unexpected object-shape parse: %+v", objShape.NetworkVolumeIDs)
+	}
+}
+
 func TestGetEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/endpoints/ep-123" {


### PR DESCRIPTION
## problem

`runpodctl serverless get` and `serverless list` both fail for every endpoint that has a network volume attached:

```
failed to parse response: json: cannot unmarshal string into Go struct field Endpoint.networkVolumeIds of type api.EndpointNetworkVolume
```

the rest read endpoint returns `networkVolumeIds` as an array of bare id strings:

```json
"networkVolumeIds": ["x3s11yfqg9"]
```

but the `Endpoint` struct only accepted the graphql `saveEndpoint` **write** shape (`[{"networkVolumeId":"..."}]`). read and write shapes differ, so all serverless reads broke.

## fix

add a custom `UnmarshalJSON` on `EndpointNetworkVolume` that accepts either a bare id string (rest read) or an object (graphql write). no change to the write path.

## testing

- unit test covering both shapes (`TestEndpointNetworkVolumeIDsUnmarshal`)
- e2e against the live api: `serverless get` and `serverless list` now succeed on endpoints with attached network volumes (previously errored). read-only, no resources created.