### PR TITLE
fix: get cloud on-demand price reported as reserved without a spot price

### DIFF
--- a/cmd/cloud/getCloud.go
+++ b/cmd/cloud/getCloud.go
@@ -66,7 +66,7 @@ var GetCloudCmd = &cobra.Command{
 			}
 			onDemandPrice, ok := kv["uninterruptablePrice"].(float64)
 			onDemandPriceString := "Reserved"
-			if ok && spotPrice > 0 {
+			if ok && onDemandPrice > 0 {
 				onDemandPriceString = fmt.Sprintf("%.3f", onDemandPrice)
 			}
 			row := []string{


### PR DESCRIPTION
`onDemandPriceString`, which depends on `onDemandPrice` mistakenly gates for `spotPrice` instead of `onDemandPrice`

```go
spotPrice, ok := kv["minimumBidPrice"].(float64)
spotPriceString := "Reserved"
if ok && spotPrice > 0 {  // notice this line
    spotPriceString = fmt.Sprintf("%.3f", spotPrice)
}

onDemandPrice, ok := kv["uninterruptablePrice"].(float64)
onDemandPriceString := "Reserved"
if ok && spotPrice > 0 {  // it is incorrectly copied over here, instead of checking for onDemandPrice
     onDemandPriceString = fmt.Sprintf("%.3f", onDemandPrice)
}
```
