### PR TITLE
fix: STO-333: Centralize api env/config lookup

### DIFF
--- a/api/query.go
+++ b/api/query.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"runtime"
 	"strings"
 	"time"
 
 	"github.com/runpod/runpodctl/internal/agent"
+	"github.com/runpod/runpodctl/internal/configenv"
 	"github.com/spf13/viper"
 )
 
@@ -33,18 +33,12 @@ func Query(input Input) (res *http.Response, err error) {
 		return nil, err
 	}
 
-	apiUrl := os.Getenv("RUNPOD_GRAPHQL_URL")
-	if apiUrl == "" {
-		apiUrl = viper.GetString("apiUrl")
-	}
+	apiUrl := configenv.GraphQLURL()
 	if apiUrl == "" {
 		apiUrl = DefaultGraphQLURL
 	}
 
-	apiKey := os.Getenv("RUNPOD_API_KEY")
-	if apiKey == "" {
-		apiKey = viper.GetString("apiKey")
-	}
+	apiKey := configenv.APIKey()
 
 	// Check if the API key is present
 	if apiKey == "" {

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestQueryUsesGraphQLEndpointEnv(t *testing.T) {
 	viper.Reset()
+	t.Cleanup(viper.Reset)
 	t.Setenv("RUNPOD_API_KEY", "test-key")
 
 	restServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -18,6 +19,12 @@ func TestQueryUsesGraphQLEndpointEnv(t *testing.T) {
 	}))
 	defer restServer.Close()
 	t.Setenv("RUNPOD_API_URL", restServer.URL)
+
+	configServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("expected RUNPOD_GRAPHQL_URL to override configured apiUrl")
+	}))
+	defer configServer.Close()
+	viper.Set("apiUrl", configServer.URL)
 
 	graphqlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var input Input
@@ -41,6 +48,7 @@ func TestQueryUsesGraphQLEndpointEnv(t *testing.T) {
 
 func TestQueryFallsBackToConfiguredAPIURL(t *testing.T) {
 	viper.Reset()
+	t.Cleanup(viper.Reset)
 	t.Setenv("RUNPOD_API_KEY", "test-key")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/runpod/runpodctl/api"
 	"github.com/runpod/runpodctl/cmd/ssh"
 	internalapi "github.com/runpod/runpodctl/internal/api"
+	"github.com/runpod/runpodctl/internal/configenv"
 	"github.com/runpod/runpodctl/internal/output"
 
 	"github.com/spf13/cobra"
@@ -75,10 +76,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 func checkAPIKey() checkResult {
 	result := checkResult{Name: "api_key"}
 
-	apiKey := os.Getenv("RUNPOD_API_KEY")
-	if apiKey == "" {
-		apiKey = viper.GetString("apiKey")
-	}
+	apiKey := configenv.APIKey()
 
 	if apiKey != "" {
 		result.Status = "pass"

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"runtime"
 	"time"
 
 	"github.com/runpod/runpodctl/internal/agent"
+	"github.com/runpod/runpodctl/internal/configenv"
 	"github.com/spf13/viper"
 )
 
@@ -38,18 +38,12 @@ type Client struct {
 
 // NewClient creates a new REST API client
 func NewClient() (*Client, error) {
-	apiKey := os.Getenv("RUNPOD_API_KEY")
-	if apiKey == "" {
-		apiKey = viper.GetString("apiKey")
-	}
+	apiKey := configenv.APIKey()
 	if apiKey == "" {
 		return nil, fmt.Errorf("api key not configured. get your key at https://www.runpod.io/console/user/settings then: export RUNPOD_API_KEY=your-key OR run: runpodctl doctor")
 	}
 
-	baseURL := os.Getenv("RUNPOD_API_URL")
-	if baseURL == "" {
-		baseURL = viper.GetString("restApiUrl")
-	}
+	baseURL := configenv.RESTURL()
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/runpod/runpodctl/internal/agent"
+	"github.com/spf13/viper"
 )
 
 func TestNewClient_NoAPIKey(t *testing.T) {
@@ -30,6 +31,27 @@ func TestNewClient_WithEnvKey(t *testing.T) {
 	}
 	if client == nil {
 		t.Error("expected client to be created")
+	}
+}
+
+func TestNewClientEnvOverridesConfig(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("apiKey", "config-key")
+	viper.Set("restApiUrl", "https://config.example.test")
+	t.Setenv("RUNPOD_API_KEY", "env-key")
+	t.Setenv("RUNPOD_API_URL", "https://env.example.test")
+
+	client, err := NewClient()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.apiKey != "env-key" {
+		t.Fatalf("expected env api key, got %q", client.apiKey)
+	}
+	if client.baseURL != "https://env.example.test" {
+		t.Fatalf("expected env rest url, got %q", client.baseURL)
 	}
 }
 
@@ -145,6 +167,53 @@ func TestClient_ErrorResponse(t *testing.T) {
 	_, err = client.Get("/notfound", nil)
 	if err == nil {
 		t.Error("expected error for 404 response")
+	}
+}
+
+func TestClientGraphQLRequestEnvOverridesConfig(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	configHit := false
+	configServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		configHit = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer configServer.Close()
+	viper.Set("apiUrl", configServer.URL)
+
+	graphqlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"myself": map[string]interface{}{
+					"id":                "user-1",
+					"email":             "test@example.com",
+					"clientBalance":     1,
+					"currentSpendPerHr": 0,
+					"spendLimit":        10,
+				},
+			},
+		})
+	}))
+	defer graphqlServer.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", graphqlServer.URL)
+
+	client := &Client{
+		baseURL:    "https://rest.example.test",
+		apiKey:     "test-key",
+		httpClient: graphqlServer.Client(),
+		userAgent:  "test",
+	}
+
+	user, err := client.GetUser()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.ID != "user-1" {
+		t.Fatalf("unexpected user id: %q", user.ID)
+	}
+	if configHit {
+		t.Fatal("expected RUNPOD_GRAPHQL_URL to override configured apiUrl")
 	}
 }
 

--- a/internal/api/gpu.go
+++ b/internal/api/gpu.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spf13/viper"
+	"github.com/runpod/runpodctl/internal/configenv"
 )
 
 // GpuType represents a GPU type
@@ -53,7 +53,7 @@ type User struct {
 
 // graphqlRequest makes a GraphQL request
 func (c *Client) graphqlRequest(query string, variables map[string]interface{}) ([]byte, error) {
-	apiURL := viper.GetString("apiUrl")
+	apiURL := configenv.GraphQLURL()
 	if apiURL == "" {
 		apiURL = "https://api.runpod.io/graphql"
 	}

--- a/internal/api/graphql.go
+++ b/internal/api/graphql.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
+	"github.com/runpod/runpodctl/internal/configenv"
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh"
 )
@@ -34,18 +34,12 @@ type GraphQLInput struct {
 
 // NewGraphQLClient creates a new GraphQL client
 func NewGraphQLClient() (*GraphQLClient, error) {
-	apiKey := os.Getenv("RUNPOD_API_KEY")
-	if apiKey == "" {
-		apiKey = viper.GetString("apiKey")
-	}
+	apiKey := configenv.APIKey()
 	if apiKey == "" {
 		return nil, fmt.Errorf("api key not found. run 'runpodctl config --apiKey=xxx' or set RUNPOD_API_KEY")
 	}
 
-	apiURL := os.Getenv("RUNPOD_GRAPHQL_URL")
-	if apiURL == "" {
-		apiURL = viper.GetString("apiUrl")
-	}
+	apiURL := configenv.GraphQLURL()
 	if apiURL == "" {
 		apiURL = DefaultGraphQLURL
 	}
@@ -299,28 +293,28 @@ type PodEnvVar struct {
 
 // CreatePodGQLInput is the input for creating a pod via GraphQL
 type CreatePodGQLInput struct {
-	CloudType         string       `json:"cloudType,omitempty"`
-	ContainerDiskInGb int          `json:"containerDiskInGb"`
-	DataCenterId      string       `json:"dataCenterId,omitempty"`
-	Env               []*PodEnvVar `json:"env,omitempty"`
-	GpuCount          int          `json:"gpuCount"`
-	GpuTypeId         string       `json:"gpuTypeId,omitempty"`
-	ImageName         string       `json:"imageName,omitempty"`
-	Name              string       `json:"name,omitempty"`
-	Ports             string       `json:"ports,omitempty"`
-	StartSsh          bool         `json:"startSsh"`
-	SupportPublicIp   bool         `json:"supportPublicIp,omitempty"`
-	TemplateId        string       `json:"templateId,omitempty"`
-	VolumeInGb        int          `json:"volumeInGb,omitempty"`
-	VolumeMountPath   string       `json:"volumeMountPath,omitempty"`
-	NetworkVolumeId   string       `json:"networkVolumeId,omitempty"`
-	MinCudaVersion         string       `json:"minCudaVersion,omitempty"`
-	DockerArgs             string       `json:"dockerArgs,omitempty"`
-	ContainerRegistryAuthId string     `json:"containerRegistryAuthId,omitempty"`
-	CountryCode            string       `json:"countryCode,omitempty"`
-	StopAfter              string       `json:"stopAfter,omitempty"`
-	TerminateAfter         string       `json:"terminateAfter,omitempty"`
-	Compliance             []string     `json:"compliance,omitempty"`
+	CloudType               string       `json:"cloudType,omitempty"`
+	ContainerDiskInGb       int          `json:"containerDiskInGb"`
+	DataCenterId            string       `json:"dataCenterId,omitempty"`
+	Env                     []*PodEnvVar `json:"env,omitempty"`
+	GpuCount                int          `json:"gpuCount"`
+	GpuTypeId               string       `json:"gpuTypeId,omitempty"`
+	ImageName               string       `json:"imageName,omitempty"`
+	Name                    string       `json:"name,omitempty"`
+	Ports                   string       `json:"ports,omitempty"`
+	StartSsh                bool         `json:"startSsh"`
+	SupportPublicIp         bool         `json:"supportPublicIp,omitempty"`
+	TemplateId              string       `json:"templateId,omitempty"`
+	VolumeInGb              int          `json:"volumeInGb,omitempty"`
+	VolumeMountPath         string       `json:"volumeMountPath,omitempty"`
+	NetworkVolumeId         string       `json:"networkVolumeId,omitempty"`
+	MinCudaVersion          string       `json:"minCudaVersion,omitempty"`
+	DockerArgs              string       `json:"dockerArgs,omitempty"`
+	ContainerRegistryAuthId string       `json:"containerRegistryAuthId,omitempty"`
+	CountryCode             string       `json:"countryCode,omitempty"`
+	StopAfter               string       `json:"stopAfter,omitempty"`
+	TerminateAfter          string       `json:"terminateAfter,omitempty"`
+	Compliance              []string     `json:"compliance,omitempty"`
 }
 
 // CreatePod creates a pod via GraphQL (podFindAndDeployOnDemand)

--- a/internal/api/graphql_test.go
+++ b/internal/api/graphql_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 func TestSSHKeyMatches(t *testing.T) {
@@ -44,6 +46,27 @@ func TestSplitSSHKeyBlock(t *testing.T) {
 	}
 	if keys[1] != "ssh-rsa bbb second" {
 		t.Fatalf("unexpected second key: %q", keys[1])
+	}
+}
+
+func TestNewGraphQLClientEnvOverridesConfig(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("apiKey", "config-key")
+	viper.Set("apiUrl", "https://config.example.test/graphql")
+	t.Setenv("RUNPOD_API_KEY", "env-key")
+	t.Setenv("RUNPOD_GRAPHQL_URL", "https://env.example.test/graphql")
+
+	client, err := NewGraphQLClient()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.apiKey != "env-key" {
+		t.Fatalf("expected env api key, got %q", client.apiKey)
+	}
+	if client.url != "https://env.example.test/graphql" {
+		t.Fatalf("expected env graphql url, got %q", client.url)
 	}
 }
 

--- a/internal/configenv/configenv.go
+++ b/internal/configenv/configenv.go
@@ -1,0 +1,32 @@
+package configenv
+
+import (
+	"os"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	APIKeyEnv     = "RUNPOD_API_KEY"
+	RESTURLEnv    = "RUNPOD_API_URL"
+	GraphQLURLEnv = "RUNPOD_GRAPHQL_URL"
+)
+
+func APIKey() string {
+	return envOrConfig(APIKeyEnv, "apiKey")
+}
+
+func RESTURL() string {
+	return envOrConfig(RESTURLEnv, "restApiUrl")
+}
+
+func GraphQLURL() string {
+	return envOrConfig(GraphQLURLEnv, "apiUrl")
+}
+
+func envOrConfig(envKey, configKey string) string {
+	if value := os.Getenv(envKey); value != "" {
+		return value
+	}
+	return viper.GetString(configKey)
+}


### PR DESCRIPTION
# STO-333: Centralize api env/config lookup

Add configenv helpers for api key, rest url, and graphql url lookup
Route rest, graphql, doctor, and legacy query paths through them

Previously env vars were inconsistently used as overrides across the project. This makes them consistently override other options.