### PR TITLE
STO333, STO334, STO335

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -172,6 +172,7 @@ type ModelVersionStatusMutationResult struct {
 type AddModelToRepoInput struct {
 	Owner               string                 `json:"owner,omitempty"`
 	Name                string                 `json:"name"`
+	Provider            string                 `json:"provider,omitempty"`
 	CredentialType      string                 `json:"credentialType,omitempty"`
 	CredentialReference string                 `json:"credentialReference,omitempty"`
 	ModelStatus         string                 `json:"modelStatus,omitempty"`
@@ -234,6 +235,7 @@ func AddModelToRepo(input *AddModelToRepoInput) (*Model, error) {
 	}
 
 	addString("owner", input.Owner)
+	addString("provider", input.Provider)
 	addString("credentialType", input.CredentialType)
 	addString("credentialReference", input.CredentialReference)
 	addString("modelStatus", input.ModelStatus)
@@ -346,7 +348,9 @@ func GetModels(input *GetModelsInput) ([]*Model, error) {
                 updatedAt
         }
         versions {
+                uuid
                 hash
+                versionHash
                 status
                 metadata
                 createdAt

--- a/api/model.go
+++ b/api/model.go
@@ -49,7 +49,8 @@ type ModelVersion struct {
 
 // ModelVersionStatus constants used when updating a model version's status.
 const (
-	ModelVersionStatusReady = "READY"
+	ModelVersionStatusReady      = "READY"
+	ModelVersionStatusPodRemoved = "POD_REMOVED"
 )
 
 // ModelRepoUpload describes the multipart upload session returned by createModelRepoUpload.
@@ -195,6 +196,13 @@ type GetModelInput struct {
 type RemoveModelInput struct {
 	Owner string `json:"owner"`
 	Name  string `json:"name"`
+}
+
+// UpdateModelVersionStatusInput captures the identifier and target status for a model version.
+type UpdateModelVersionStatusInput struct {
+	Hash   string `json:"hash,omitempty"`
+	UUID   string `json:"uuid,omitempty"`
+	Status string `json:"status"`
 }
 
 // CreateModelRepoUploadInput defines the payload used to start a multipart upload for a model version.
@@ -461,7 +469,9 @@ func GetModel(input *GetModelInput) (*Model, error) {
                                         updatedAt
                                 }
                                 versions {
+                                        uuid
                                         hash
+                                        versionHash
                                         status
                                         metadata
                                         createdAt
@@ -810,40 +820,19 @@ func CompleteModelRepoUpload(sessionID string) (*CompleteModelRepoUploadResult, 
 	return result, nil
 }
 
-// UpdateModelVersionStatus updates the status for a model version in the repository.
+// UpdateModelVersionStatus updates the status for a model version by hash.
 func UpdateModelVersionStatus(hash, status string) (*ModelVersion, error) {
-	hash = strings.TrimSpace(hash)
-	if hash == "" {
-		return nil, fmt.Errorf("hash cannot be empty")
-	}
+	return UpdateModelVersionStatusByIdentifier(&UpdateModelVersionStatusInput{
+		Hash:   hash,
+		Status: status,
+	})
+}
 
-	status = strings.TrimSpace(status)
-	if status == "" {
-		return nil, fmt.Errorf("status cannot be empty")
-	}
-
-	variables := map[string]interface{}{
-		"hash":   hash,
-		"status": status,
-	}
-
-	gqlInput := Input{
-		Query: `
-                mutation updateModelVersionStatus($hash: ID!, $status: ModelVersionStatus!) {
-                        updateModelVersionStatus(hash: $hash, status: $status) {
-                                success
-                                message
-                                modelVersion {
-                                        hash
-                                        status
-                                        metadata
-                                        createdAt
-                                        updatedAt
-                                }
-                        }
-                }
-                `,
-		Variables: variables,
+// UpdateModelVersionStatusByIdentifier updates the status for a model version by hash or UUID.
+func UpdateModelVersionStatusByIdentifier(input *UpdateModelVersionStatusInput) (*ModelVersion, error) {
+	gqlInput, err := newUpdateModelVersionStatusInput(input)
+	if err != nil {
+		return nil, err
 	}
 
 	res, err := Query(gqlInput)
@@ -888,4 +877,55 @@ func UpdateModelVersionStatus(hash, status string) (*ModelVersion, error) {
 	}
 
 	return result.ModelVersion, nil
+}
+
+func newUpdateModelVersionStatusInput(input *UpdateModelVersionStatusInput) (Input, error) {
+	if input == nil {
+		return Input{}, fmt.Errorf("input cannot be nil")
+	}
+
+	hash := strings.TrimSpace(input.Hash)
+	uuid := strings.TrimSpace(input.UUID)
+	if hash == "" && uuid == "" {
+		return Input{}, fmt.Errorf("either hash or uuid must be provided")
+	}
+	if hash != "" && uuid != "" {
+		return Input{}, fmt.Errorf("only one of hash or uuid can be provided")
+	}
+
+	status := strings.TrimSpace(input.Status)
+	if status == "" {
+		return Input{}, fmt.Errorf("status cannot be empty")
+	}
+
+	variables := map[string]interface{}{
+		"status": status,
+	}
+	if hash != "" {
+		variables["hash"] = hash
+	}
+	if uuid != "" {
+		variables["uuid"] = uuid
+	}
+
+	return Input{
+		Query: `
+                mutation updateModelVersionStatus($uuid: ID, $hash: ID, $status: ModelVersionStatus!) {
+                        updateModelVersionStatus(uuid: $uuid, hash: $hash, status: $status) {
+                                success
+                                message
+                                modelVersion {
+                                        uuid
+                                        hash
+                                        versionHash
+                                        status
+                                        metadata
+                                        createdAt
+                                        updatedAt
+                                }
+                        }
+                }
+                `,
+		Variables: variables,
+	}, nil
 }

--- a/api/model_test.go
+++ b/api/model_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestAddModelToRepoSendsProviderWhenProvided(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	var provider string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input Input
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		variablesInput, ok := input.Variables["input"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected input variables, got %#v", input.Variables["input"])
+		}
+		if value, ok := variablesInput["provider"].(string); ok {
+			provider = value
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"addModelToRepo": map[string]interface{}{
+					"success": true,
+					"model": map[string]interface{}{
+						"id":       "model-id",
+						"owner":    "user-id",
+						"name":     "test-model",
+						"provider": "LOCAL",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", server.URL)
+
+	model, err := AddModelToRepo(&AddModelToRepoInput{
+		Owner:    "user-id",
+		Name:     "test-model",
+		Provider: "LOCAL",
+	})
+	if err != nil {
+		t.Fatalf("AddModelToRepo returned error: %v", err)
+	}
+	if provider != "LOCAL" {
+		t.Fatalf("expected provider LOCAL in request, got %q", provider)
+	}
+	if model.Provider != "LOCAL" {
+		t.Fatalf("expected response provider LOCAL, got %q", model.Provider)
+	}
+}
+
+func TestGetModelsRequestsVersionIdentifiers(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	var query string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input Input
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		query = input.Query
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"myModels": []map[string]interface{}{
+					{
+						"id":       "model-id",
+						"owner":    "user-id",
+						"name":     "test-model",
+						"provider": "LOCAL",
+						"versions": []map[string]interface{}{
+							{
+								"uuid":        "version-uuid",
+								"hash":        "version-hash",
+								"versionHash": "legacy-version-hash",
+							},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", server.URL)
+
+	models, err := GetModels(&GetModelsInput{Name: "test-model"})
+	if err != nil {
+		t.Fatalf("GetModels returned error: %v", err)
+	}
+	if !strings.Contains(query, "uuid") {
+		t.Fatalf("expected GetModels query to request version uuid, got %s", query)
+	}
+	if !strings.Contains(query, "versionHash") {
+		t.Fatalf("expected GetModels query to request versionHash, got %s", query)
+	}
+	if len(models) != 1 || len(models[0].Versions) != 1 {
+		t.Fatalf("expected one model version, got %#v", models)
+	}
+	version := models[0].Versions[0]
+	if version.UUID != "version-uuid" || version.Hash != "version-hash" || version.VersionHash != "legacy-version-hash" {
+		t.Fatalf("expected version identifiers to decode, got %#v", version)
+	}
+}

--- a/api/model_test.go
+++ b/api/model_test.go
@@ -117,3 +117,51 @@ func TestGetModelsRequestsVersionIdentifiers(t *testing.T) {
 		t.Fatalf("expected version identifiers to decode, got %#v", version)
 	}
 }
+
+func TestUpdateModelVersionStatusByIdentifierUsesUUID(t *testing.T) {
+	input, err := newUpdateModelVersionStatusInput(&UpdateModelVersionStatusInput{
+		UUID:   "version-uuid",
+		Status: ModelVersionStatusPodRemoved,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if input.Variables["uuid"] != "version-uuid" {
+		t.Fatalf("expected uuid variable, got %#v", input.Variables)
+	}
+	if _, ok := input.Variables["hash"]; ok {
+		t.Fatalf("did not expect hash variable, got %#v", input.Variables)
+	}
+	if input.Variables["status"] != ModelVersionStatusPodRemoved {
+		t.Fatalf("expected status %q, got %#v", ModelVersionStatusPodRemoved, input.Variables["status"])
+	}
+}
+
+func TestUpdateModelVersionStatusByIdentifierUsesHash(t *testing.T) {
+	input, err := newUpdateModelVersionStatusInput(&UpdateModelVersionStatusInput{
+		Hash:   "version-hash",
+		Status: ModelVersionStatusPodRemoved,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if input.Variables["hash"] != "version-hash" {
+		t.Fatalf("expected hash variable, got %#v", input.Variables)
+	}
+	if _, ok := input.Variables["uuid"]; ok {
+		t.Fatalf("did not expect uuid variable, got %#v", input.Variables)
+	}
+}
+
+func TestUpdateModelVersionStatusByIdentifierValidatesIdentifier(t *testing.T) {
+	if _, err := newUpdateModelVersionStatusInput(&UpdateModelVersionStatusInput{Status: ModelVersionStatusPodRemoved}); err == nil {
+		t.Fatal("expected missing identifier error")
+	}
+	if _, err := newUpdateModelVersionStatusInput(&UpdateModelVersionStatusInput{
+		UUID:   "version-uuid",
+		Hash:   "version-hash",
+		Status: ModelVersionStatusPodRemoved,
+	}); err == nil {
+		t.Fatal("expected conflicting identifier error")
+	}
+}

--- a/api/query.go
+++ b/api/query.go
@@ -6,12 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"runtime"
 	"strings"
 	"time"
 
 	"github.com/runpod/runpodctl/internal/agent"
+	"github.com/runpod/runpodctl/internal/configenv"
 	"github.com/spf13/viper"
 )
 
@@ -33,18 +33,12 @@ func Query(input Input) (res *http.Response, err error) {
 		return nil, err
 	}
 
-	apiUrl := os.Getenv("RUNPOD_GRAPHQL_URL")
-	if apiUrl == "" {
-		apiUrl = viper.GetString("apiUrl")
-	}
+	apiUrl := configenv.GraphQLURL()
 	if apiUrl == "" {
 		apiUrl = DefaultGraphQLURL
 	}
 
-	apiKey := os.Getenv("RUNPOD_API_KEY")
-	if apiKey == "" {
-		apiKey = viper.GetString("apiKey")
-	}
+	apiKey := configenv.APIKey()
 
 	// Check if the API key is present
 	if apiKey == "" {

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestQueryUsesGraphQLEndpointEnv(t *testing.T) {
 	viper.Reset()
+	t.Cleanup(viper.Reset)
 	t.Setenv("RUNPOD_API_KEY", "test-key")
 
 	restServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -18,6 +19,12 @@ func TestQueryUsesGraphQLEndpointEnv(t *testing.T) {
 	}))
 	defer restServer.Close()
 	t.Setenv("RUNPOD_API_URL", restServer.URL)
+
+	configServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("expected RUNPOD_GRAPHQL_URL to override configured apiUrl")
+	}))
+	defer configServer.Close()
+	viper.Set("apiUrl", configServer.URL)
 
 	graphqlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var input Input
@@ -41,6 +48,7 @@ func TestQueryUsesGraphQLEndpointEnv(t *testing.T) {
 
 func TestQueryFallsBackToConfiguredAPIURL(t *testing.T) {
 	viper.Reset()
+	t.Cleanup(viper.Reset)
 	t.Setenv("RUNPOD_API_KEY", "test-key")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/runpod/runpodctl/api"
 	"github.com/runpod/runpodctl/cmd/ssh"
 	internalapi "github.com/runpod/runpodctl/internal/api"
+	"github.com/runpod/runpodctl/internal/configenv"
 	"github.com/runpod/runpodctl/internal/output"
 
 	"github.com/spf13/cobra"
@@ -75,10 +76,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 func checkAPIKey() checkResult {
 	result := checkResult{Name: "api_key"}
 
-	apiKey := os.Getenv("RUNPOD_API_KEY")
-	if apiKey == "" {
-		apiKey = viper.GetString("apiKey")
-	}
+	apiKey := configenv.APIKey()
 
 	if apiKey != "" {
 		result.Status = "pass"

--- a/cmd/model/addModelToRepo.go
+++ b/cmd/model/addModelToRepo.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -17,6 +18,7 @@ import (
 	"github.com/runpod/runpodctl/api"
 	"github.com/runpod/runpodctl/internal/output"
 
+	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -34,11 +36,16 @@ var (
 	addModelContentType         string
 	addModelDirectoryPath       string
 	addModelMetadata            map[string]string
+	addModelWaitForHash         bool
+	addModelHashTimeout         time.Duration
+	addModelVerbose             bool
 )
 
 const (
 	graphqlTimeoutFlagName   = "graphql-timeout"
 	modelGraphQLTimeoutValue = time.Minute
+	modelHashPollInterval    = 5 * time.Second
+	modelHashWaitTimeout     = 30 * time.Minute
 )
 
 // The GraphQL requests for uploading a model can take longer than the default
@@ -56,7 +63,6 @@ func setModelGraphQLTimeout(cmd *cobra.Command) {
 		}
 
 		viper.Set(api.GraphQLTimeoutKey, modelGraphQLTimeoutValue)
-		fmt.Fprintf(os.Stderr, "--graphql-timeout not set; defaulting to %s for model creation operations\n", modelGraphQLTimeoutValue)
 		return
 	}
 
@@ -68,7 +74,6 @@ func setModelGraphQLTimeout(cmd *cobra.Command) {
 	}
 
 	viper.Set(api.GraphQLTimeoutKey, modelGraphQLTimeoutValue)
-	fmt.Fprintf(os.Stderr, "defaulting graphql timeout to %s for model creation operations\n", modelGraphQLTimeoutValue)
 }
 
 type completedPart struct {
@@ -96,17 +101,51 @@ type uploadedModelFile struct {
 }
 
 type modelAddOutput struct {
-	Model         *api.Model           `json:"model,omitempty"`
-	Upload        *api.ModelRepoUpload `json:"upload,omitempty"`
-	UploadedFiles []uploadedModelFile  `json:"uploadedFiles,omitempty"`
+	Model          *api.Model           `json:"model,omitempty"`
+	Upload         *api.ModelRepoUpload `json:"upload,omitempty"`
+	UploadedFiles  []uploadedModelFile  `json:"uploadedFiles,omitempty"`
+	ModelSizeBytes *int64               `json:"modelSizeBytes,omitempty"`
+	ModelHash      string               `json:"modelHash,omitempty"`
+	ModelURL       string               `json:"modelUrl,omitempty"`
+}
+
+type compactModelAddOutput struct {
+	Model compactModel `json:"model"`
+}
+
+type compactModel struct {
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Owner string `json:"owner,omitempty"`
+}
+
+type modelReadyOutput struct {
+	Owner     string
+	Name      string
+	ModelHash string
+	ModelURL  string
+}
+
+type modelUploadProgress interface {
+	Add64(int64) error
+	Finish() error
+	Clear() error
+}
+
+type progressReader struct {
+	reader   io.Reader
+	progress modelUploadProgress
 }
 
 // TODO: replace the manual completion call with github.com/aws/aws-sdk-go-v2/service/s3's
 // CompleteMultipartUpload to rely on the SDK for payload formatting and signing logic.
 var (
+	addModelToRepo          = api.AddModelToRepo
 	createModelRepoUpload   = api.CreateModelRepoUpload
 	completeModelRepoUpload = api.CompleteModelRepoUpload
-	completeModelUploadFile = completeModelUpload
+	completeModelUploadFile = completeModelUploadWithProgress
+	getModelsForAdd         = api.GetModels
+	sleepModelHashPoll      = waitModelHashPoll
 )
 
 var addCmd = &cobra.Command{
@@ -146,6 +185,9 @@ func bindAddModelFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&addModelContentType, "content-type", "", "upload content type")
 	cmd.Flags().StringVar(&addModelDirectoryPath, "model-path", "", "directory containing model files to upload")
 	cmd.Flags().StringToStringVar(&addModelMetadata, "metadata", nil, "metadata key=value pairs")
+	cmd.Flags().BoolVar(&addModelWaitForHash, "wait-for-hash", false, "wait for completed model-path uploads to be hashed")
+	cmd.Flags().DurationVar(&addModelHashTimeout, "hash-timeout", modelHashWaitTimeout, "maximum duration to wait for --wait-for-hash (0 disables timeout)")
+	cmd.Flags().BoolVarP(&addModelVerbose, "verbose", "v", false, "include upload details in wait-for-hash output")
 }
 
 func runAddModel(cmd *cobra.Command, args []string) {
@@ -173,12 +215,18 @@ func runAddModel(cmd *cobra.Command, args []string) {
 		addModelCreateUpload = true
 	}
 
+	isUploadFlow := addModelCreateUpload || addModelFileName != "" || addModelFileSize != "" || addModelPartSize != "" || addModelContentType != ""
+
 	var metadata map[string]interface{}
 	if len(addModelMetadata) > 0 {
 		metadata = make(map[string]interface{}, len(addModelMetadata))
 		for key, value := range addModelMetadata {
 			metadata[key] = value
 		}
+	}
+
+	if addModelWaitForHash && len(modelFiles) == 0 {
+		cobra.CheckErr(fmt.Errorf("--wait-for-hash requires --model-path"))
 	}
 
 	input := &api.AddModelToRepoInput{
@@ -189,8 +237,11 @@ func runAddModel(cmd *cobra.Command, args []string) {
 		ModelStatus:         addModelStatus,
 		Metadata:            metadata,
 	}
+	if isUploadFlow {
+		input.Provider = "LOCAL"
+	}
 
-	model, err := api.AddModelToRepo(input)
+	model, err := addModelToRepo(input)
 	if err != nil {
 		if handleModelRepoError(err) {
 			return
@@ -218,9 +269,34 @@ func runAddModel(cmd *cobra.Command, args []string) {
 	uploadInput.Name = addModelName
 
 	if len(modelFiles) > 0 {
-		uploadedFiles, err := uploadModelFiles(modelFiles, uploadInput)
+		uploadedFiles, uploadModel, modelVersionUUID, err := uploadModelFiles(modelFiles, uploadInput)
 		cobra.CheckErr(err)
-		printModelAddOutput(cmd, modelAddOutput{Model: model, UploadedFiles: uploadedFiles})
+		if uploadModel != nil {
+			model = uploadModel
+		}
+		modelSizeBytes := totalModelFileSize(modelFiles)
+		result := modelAddOutput{Model: model, UploadedFiles: uploadedFiles, ModelSizeBytes: &modelSizeBytes}
+		if addModelWaitForHash {
+			if modelVersionUUID == "" {
+				cobra.CheckErr(fmt.Errorf("upload response missing model version uuid required by --wait-for-hash"))
+			}
+			ctx := context.Background()
+			var cancel context.CancelFunc
+			if addModelHashTimeout > 0 {
+				ctx, cancel = context.WithTimeout(ctx, addModelHashTimeout)
+				defer cancel()
+			}
+			ready, err := waitForUploadedModelHash(ctx, addModelOwner, addModelName, model, modelVersionUUID, modelHashPollInterval)
+			cobra.CheckErr(err)
+			result.ModelHash = ready.ModelHash
+			result.ModelURL = ready.ModelURL
+			printModelReadyURL(ready.ModelURL)
+			if !addModelVerbose {
+				printCompactModelAddOutput(cmd, model)
+				return
+			}
+		}
+		printModelAddOutput(cmd, result)
 		return
 	}
 
@@ -239,6 +315,9 @@ func runAddModel(cmd *cobra.Command, args []string) {
 
 	if result.Upload == nil {
 		cobra.CheckErr(fmt.Errorf("upload response missing upload session details"))
+	}
+	if result.Model != nil {
+		model = result.Model
 	}
 
 	printModelAddOutput(cmd, modelAddOutput{Model: model, Upload: result.Upload})
@@ -298,9 +377,239 @@ func collectModelFiles(dir string) ([]modelFile, error) {
 	return files, nil
 }
 
-func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInput) ([]uploadedModelFile, error) {
+func (r progressReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 && r.progress != nil {
+		_ = r.progress.Add64(int64(n))
+	}
+	return n, err
+}
+
+func totalModelFileSize(files []modelFile) int64 {
+	var total int64
+	for _, file := range files {
+		total += file.Size
+	}
+	return total
+}
+
+func stderrIsTerminal() bool {
+	info, err := os.Stderr.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+func newModelUploadProgress(totalBytes int64) modelUploadProgress {
+	if totalBytes <= 0 || !stderrIsTerminal() {
+		return nil
+	}
+
+	return progressbar.NewOptions64(totalBytes,
+		progressbar.OptionOnCompletion(func() {
+			fmt.Fprintln(os.Stderr)
+		}),
+		progressbar.OptionSetDescription("uploading model"),
+		progressbar.OptionSetWidth(20),
+		progressbar.OptionSetRenderBlankState(true),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionShowCount(),
+		progressbar.OptionSetPredictTime(true),
+		progressbar.OptionThrottle(100*time.Millisecond),
+		progressbar.OptionSetWriter(os.Stderr),
+	)
+}
+
+func printCompletedModelUploadSize(totalBytes int64) {
+	fmt.Fprintf(os.Stderr, "model size: %d bytes\n", totalBytes)
+}
+
+func waitForUploadedModelHash(ctx context.Context, owner, name string, uploadedModel *api.Model, modelVersionUUID string, pollInterval time.Duration) (*modelReadyOutput, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	name = strings.TrimSpace(name)
+	if name == "" && uploadedModel != nil {
+		name = strings.TrimSpace(uploadedModel.Name)
+	}
+	if name == "" {
+		return nil, fmt.Errorf("model name is required to wait for hashing")
+	}
+	modelVersionUUID = strings.TrimSpace(modelVersionUUID)
+	if modelVersionUUID == "" {
+		return nil, fmt.Errorf("model version uuid is required to wait for hashing")
+	}
+
+	fmt.Fprint(os.Stderr, "waiting for model to be hashed")
+	defer fmt.Fprintln(os.Stderr)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("timed out waiting for model hash: %w", err)
+		}
+
+		models, err := getModelsForAdd(&api.GetModelsInput{Name: name})
+		if err != nil {
+			return nil, fmt.Errorf("get model hash: %w", err)
+		}
+
+		model := findUploadedModel(models, owner, name, uploadedModel)
+		hash := uploadedModelVersionHash(model, modelVersionUUID)
+		if hash != "" {
+			ownerID := modelOwnerForURL(owner, uploadedModel, model)
+			if ownerID == "" {
+				return nil, fmt.Errorf("model owner is required to build model url")
+			}
+			modelName := modelNameForURL(name, uploadedModel, model)
+			if modelName == "" {
+				return nil, fmt.Errorf("model name is required to build model url")
+			}
+
+			modelURL := formatModelURL(ownerID, modelName, hash)
+			return &modelReadyOutput{
+				Owner:     ownerID,
+				Name:      modelName,
+				ModelHash: hash,
+				ModelURL:  modelURL,
+			}, nil
+		}
+
+		fmt.Fprint(os.Stderr, ".")
+		if err := sleepModelHashPoll(ctx, pollInterval); err != nil {
+			return nil, fmt.Errorf("timed out waiting for model hash: %w", err)
+		}
+	}
+}
+
+func uploadedModelVersionHash(model *api.Model, modelVersionUUID string) string {
+	if model == nil {
+		return ""
+	}
+	modelVersionUUID = strings.TrimSpace(modelVersionUUID)
+	if modelVersionUUID == "" {
+		return ""
+	}
+	for _, version := range model.Versions {
+		if version == nil || strings.TrimSpace(version.UUID) != modelVersionUUID {
+			continue
+		}
+		if hash := strings.TrimSpace(version.Hash); hash != "" {
+			return hash
+		}
+		if hash := strings.TrimSpace(version.VersionHash); hash != "" {
+			return hash
+		}
+		return ""
+	}
+	return ""
+}
+
+func waitModelHashPoll(ctx context.Context, duration time.Duration) error {
+	if duration <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func findUploadedModel(models []*api.Model, owner, name string, uploadedModel *api.Model) *api.Model {
+	owner = strings.TrimSpace(owner)
+	name = strings.TrimSpace(name)
+	uploadedID := ""
+	uploadedOwner := ""
+	uploadedName := ""
+	if uploadedModel != nil {
+		uploadedID = strings.TrimSpace(uploadedModel.ID)
+		uploadedOwner = strings.TrimSpace(uploadedModel.Owner)
+		uploadedName = strings.TrimSpace(uploadedModel.Name)
+	}
+	if owner == "" {
+		owner = uploadedOwner
+	}
+	if name == "" {
+		name = uploadedName
+	}
+
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		if uploadedID != "" && strings.TrimSpace(model.ID) == uploadedID {
+			return model
+		}
+		if name != "" && strings.TrimSpace(model.Name) != name {
+			continue
+		}
+		if owner != "" && strings.TrimSpace(model.Owner) != owner {
+			continue
+		}
+		return model
+	}
+
+	return nil
+}
+
+func modelOwnerForURL(owner string, uploadedModel, polledModel *api.Model) string {
+	if owner = strings.TrimSpace(owner); owner != "" {
+		return owner
+	}
+	if polledModel != nil {
+		if owner = strings.TrimSpace(polledModel.Owner); owner != "" {
+			return owner
+		}
+	}
+	if uploadedModel != nil {
+		return strings.TrimSpace(uploadedModel.Owner)
+	}
+	return ""
+}
+
+func modelNameForURL(name string, uploadedModel, polledModel *api.Model) string {
+	if name = strings.TrimSpace(name); name != "" {
+		return name
+	}
+	if polledModel != nil {
+		if name = strings.TrimSpace(polledModel.Name); name != "" {
+			return name
+		}
+	}
+	if uploadedModel != nil {
+		return strings.TrimSpace(uploadedModel.Name)
+	}
+	return ""
+}
+
+func formatModelURL(owner, name, hash string) string {
+	return fmt.Sprintf("https://local/%s/%s:%s", owner, name, hash)
+}
+
+func printModelReadyURL(modelURL string) {
+	fmt.Fprintf(os.Stderr, "model is ready to deploy, your model url is: \"%s\"\n", shellDoubleQuoteValue(modelURL))
+}
+
+func shellDoubleQuoteValue(value string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		`$`, `\$`,
+		"`", "\\`",
+	)
+	return replacer.Replace(value)
+}
+
+func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInput) ([]uploadedModelFile, *api.Model, string, error) {
 	var modelVersionUUID string
+	var uploadModel *api.Model
 	uploadedFiles := make([]uploadedModelFile, 0, len(files))
+	totalSize := totalModelFileSize(files)
+	progress := newModelUploadProgress(totalSize)
 
 	for i, file := range files {
 		input := *baseInput
@@ -310,26 +619,44 @@ func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInp
 
 		result, err := createModelRepoUpload(&input)
 		if err != nil {
-			return nil, fmt.Errorf("create upload for %s: %w", file.RelativePath, err)
+			if progress != nil {
+				_ = progress.Clear()
+			}
+			return nil, nil, "", fmt.Errorf("create upload for %s: %w", file.RelativePath, err)
 		}
 		if result.Upload == nil {
-			return nil, fmt.Errorf("upload response missing upload session details for %s", file.RelativePath)
+			if progress != nil {
+				_ = progress.Clear()
+			}
+			return nil, nil, "", fmt.Errorf("upload response missing upload session details for %s", file.RelativePath)
+		}
+		if result.Model != nil {
+			uploadModel = result.Model
 		}
 		if modelVersionUUID == "" {
 			if result.Version != nil {
 				modelVersionUUID = strings.TrimSpace(result.Version.UUID)
 			}
 			if modelVersionUUID == "" && i < len(files)-1 {
-				return nil, fmt.Errorf("upload response missing model version uuid for %s", file.RelativePath)
+				if progress != nil {
+					_ = progress.Clear()
+				}
+				return nil, nil, "", fmt.Errorf("upload response missing model version uuid for %s", file.RelativePath)
 			}
 		}
 
-		if err = completeModelUploadFile(result.Upload, file.AbsolutePath); err != nil {
-			return nil, fmt.Errorf("upload %s: %w", file.RelativePath, err)
+		if err = completeModelUploadFile(result.Upload, file.AbsolutePath, progress); err != nil {
+			if progress != nil {
+				_ = progress.Clear()
+			}
+			return nil, nil, "", fmt.Errorf("upload %s: %w", file.RelativePath, err)
 		}
 
 		if result.Upload.SessionID == "" {
-			return nil, fmt.Errorf("upload %s: missing session identifier for completion", file.RelativePath)
+			if progress != nil {
+				_ = progress.Clear()
+			}
+			return nil, nil, "", fmt.Errorf("upload %s: missing session identifier for completion", file.RelativePath)
 		}
 
 		uploadedFiles = append(uploadedFiles, uploadedModelFile{
@@ -342,14 +669,22 @@ func uploadModelFiles(files []modelFile, baseInput *api.CreateModelRepoUploadInp
 	for i := range uploadedFiles {
 		completion, err := completeModelRepoUpload(uploadedFiles[i].SessionID)
 		if err != nil {
-			return nil, fmt.Errorf("complete upload session for %s: %w", uploadedFiles[i].RelativePath, err)
+			if progress != nil {
+				_ = progress.Clear()
+			}
+			return nil, nil, "", fmt.Errorf("complete upload session for %s: %w", uploadedFiles[i].RelativePath, err)
 		}
 
 		uploadedFiles[i].SessionID = completion.SessionID
 		uploadedFiles[i].Status = completion.Status
 	}
 
-	return uploadedFiles, nil
+	if progress != nil {
+		_ = progress.Finish()
+	}
+	printCompletedModelUploadSize(totalSize)
+
+	return uploadedFiles, uploadModel, modelVersionUUID, nil
 }
 
 func printModelAddOutput(cmd *cobra.Command, result modelAddOutput) {
@@ -357,7 +692,24 @@ func printModelAddOutput(cmd *cobra.Command, result modelAddOutput) {
 	cobra.CheckErr(output.Print(result, &output.Config{Format: format}))
 }
 
+func printCompactModelAddOutput(cmd *cobra.Command, model *api.Model) {
+	format := output.ParseFormat(cmd.Flag("output").Value.String())
+	compact := compactModel{}
+	if model != nil {
+		compact.ID = strings.TrimSpace(model.ID)
+		compact.Name = strings.TrimSpace(model.Name)
+		compact.Owner = strings.TrimSpace(model.Owner)
+	}
+	cobra.CheckErr(output.Print(compactModelAddOutput{
+		Model: compact,
+	}, &output.Config{Format: format}))
+}
+
 func completeModelUpload(upload *api.ModelRepoUpload, artifactPath string) error {
+	return completeModelUploadWithProgress(upload, artifactPath, nil)
+}
+
+func completeModelUploadWithProgress(upload *api.ModelRepoUpload, artifactPath string, progress modelUploadProgress) error {
 	if upload == nil {
 		return fmt.Errorf("upload details are required")
 	}
@@ -409,8 +761,12 @@ func completeModelUpload(upload *api.ModelRepoUpload, artifactPath string) error
 			chunkSize = remaining
 		}
 
-		section := io.NewSectionReader(file, offset, chunkSize)
-		req, err := http.NewRequest(http.MethodPut, part.URL, section)
+		var body io.Reader = io.NewSectionReader(file, offset, chunkSize)
+		if progress != nil {
+			body = progressReader{reader: body, progress: progress}
+		}
+
+		req, err := http.NewRequest(http.MethodPut, part.URL, body)
 		if err != nil {
 			return fmt.Errorf("create request for part %d: %w", part.PartNumber, err)
 		}

--- a/cmd/model/addModelToRepo_timeout_test.go
+++ b/cmd/model/addModelToRepo_timeout_test.go
@@ -1,8 +1,14 @@
 package model
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,8 +21,6 @@ func TestSetModelGraphQLTimeoutWithoutInheritedFlag(t *testing.T) {
 	viper.Reset()
 
 	cmd := &cobra.Command{Use: "add"}
-	// CLAUDE.md: informational output must not corrupt stdout for JSON
-	// consumers — the "defaulting graphql timeout" notice must land on stderr.
 	stdout, stderr := captureStdStreams(t, func() {
 		setModelGraphQLTimeout(cmd)
 	})
@@ -27,8 +31,8 @@ func TestSetModelGraphQLTimeoutWithoutInheritedFlag(t *testing.T) {
 	if stdout != "" {
 		t.Fatalf("stdout must remain empty, got %q", stdout)
 	}
-	if stderr == "" {
-		t.Fatal("expected timeout-default notice on stderr, got empty")
+	if stderr != "" {
+		t.Fatalf("stderr must remain empty, got %q", stderr)
 	}
 }
 
@@ -87,6 +91,237 @@ func TestSetModelGraphQLTimeoutSkipsWhenInheritedFlagChanged(t *testing.T) {
 	}
 }
 
+func TestRunAddModelPathWaitForHashPrintsCompactOutput(t *testing.T) {
+	resetAddModelGlobals(t)
+	oldAddModelToRepo := addModelToRepo
+	oldCreateModelRepoUpload := createModelRepoUpload
+	oldCompleteModelUploadFile := completeModelUploadFile
+	oldCompleteModelRepoUpload := completeModelRepoUpload
+	oldGetModelsForAdd := getModelsForAdd
+	t.Cleanup(func() {
+		addModelToRepo = oldAddModelToRepo
+		createModelRepoUpload = oldCreateModelRepoUpload
+		completeModelUploadFile = oldCompleteModelUploadFile
+		completeModelRepoUpload = oldCompleteModelRepoUpload
+		getModelsForAdd = oldGetModelsForAdd
+	})
+
+	modelDir := t.TempDir()
+	modelFile := filepath.Join(modelDir, "weights.bin")
+	if err := os.WriteFile(modelFile, []byte("model"), 0600); err != nil {
+		t.Fatalf("write model file: %v", err)
+	}
+
+	addModelOwner = "user-id"
+	addModelName = "test-model"
+	addModelDirectoryPath = modelDir
+	addModelWaitForHash = true
+
+	var addInput *api.AddModelToRepoInput
+	addModelToRepo = func(input *api.AddModelToRepoInput) (*api.Model, error) {
+		copy := *input
+		addInput = &copy
+		return &api.Model{
+			ID:       "model-id",
+			Owner:    "user-id",
+			Name:     "test-model",
+			Provider: "huggingface",
+		}, nil
+	}
+	createModelRepoUpload = func(input *api.CreateModelRepoUploadInput) (*api.ModelRepoMutationResult, error) {
+		return &api.ModelRepoMutationResult{
+			Success: true,
+			Model: &api.Model{
+				ID:       "model-id",
+				Owner:    "user-id",
+				Name:     "test-model",
+				Provider: "LOCAL",
+			},
+			Version: &api.ModelVersion{UUID: "version-uuid"},
+			Upload: &api.ModelRepoUpload{
+				SessionID: "session-id",
+				Key:       "key",
+			},
+		}, nil
+	}
+	completeModelUploadFile = func(upload *api.ModelRepoUpload, artifactPath string, progress modelUploadProgress) error {
+		return nil
+	}
+	completeModelRepoUpload = func(sessionID string) (*api.CompleteModelRepoUploadResult, error) {
+		return &api.CompleteModelRepoUploadResult{SessionID: sessionID, Status: "completed"}, nil
+	}
+	getModelsForAdd = func(input *api.GetModelsInput) ([]*api.Model, error) {
+		return []*api.Model{{
+			ID:       "model-id",
+			Owner:    "user-id",
+			Name:     "test-model",
+			Provider: "LOCAL",
+			Versions: []*api.ModelVersion{{UUID: "version-uuid", Hash: "hash-123"}},
+		}}, nil
+	}
+
+	cmd := newTestAddModelCommand()
+	stdout, _ := captureStdStreams(t, func() {
+		runAddModel(cmd, nil)
+	})
+
+	if addInput == nil {
+		t.Fatal("expected addModelToRepo to be called")
+	}
+	if addInput.Provider != "LOCAL" {
+		t.Fatalf("expected upload addModelToRepo provider LOCAL, got %q", addInput.Provider)
+	}
+
+	var output compactModelAddOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if output.Model.ID != "model-id" {
+		t.Fatalf("expected compact model id, got %q", output.Model.ID)
+	}
+	if output.Model.Name != "test-model" {
+		t.Fatalf("expected compact model name, got %q", output.Model.Name)
+	}
+	if output.Model.Owner != "user-id" {
+		t.Fatalf("expected compact model owner, got %q", output.Model.Owner)
+	}
+	if strings.Contains(stdout, "uploadedFiles") || strings.Contains(stdout, "modelUrl") || strings.Contains(stdout, "modelHash") {
+		t.Fatalf("expected compact output, got %s", stdout)
+	}
+}
+
+func TestRunAddModelPathWaitForHashVerbosePrintsFullOutput(t *testing.T) {
+	resetAddModelGlobals(t)
+	oldAddModelToRepo := addModelToRepo
+	oldCreateModelRepoUpload := createModelRepoUpload
+	oldCompleteModelUploadFile := completeModelUploadFile
+	oldCompleteModelRepoUpload := completeModelRepoUpload
+	oldGetModelsForAdd := getModelsForAdd
+	t.Cleanup(func() {
+		addModelToRepo = oldAddModelToRepo
+		createModelRepoUpload = oldCreateModelRepoUpload
+		completeModelUploadFile = oldCompleteModelUploadFile
+		completeModelRepoUpload = oldCompleteModelRepoUpload
+		getModelsForAdd = oldGetModelsForAdd
+	})
+
+	modelDir := t.TempDir()
+	modelFile := filepath.Join(modelDir, "weights.bin")
+	if err := os.WriteFile(modelFile, []byte("model"), 0600); err != nil {
+		t.Fatalf("write model file: %v", err)
+	}
+
+	addModelOwner = "user-id"
+	addModelName = "test-model"
+	addModelDirectoryPath = modelDir
+	addModelWaitForHash = true
+	addModelVerbose = true
+
+	addModelToRepo = func(input *api.AddModelToRepoInput) (*api.Model, error) {
+		return &api.Model{ID: "model-id", Owner: "user-id", Name: "test-model", Provider: "huggingface"}, nil
+	}
+	createModelRepoUpload = func(input *api.CreateModelRepoUploadInput) (*api.ModelRepoMutationResult, error) {
+		return &api.ModelRepoMutationResult{
+			Success: true,
+			Model:   &api.Model{ID: "model-id", Owner: "user-id", Name: "test-model", Provider: "LOCAL"},
+			Version: &api.ModelVersion{UUID: "version-uuid"},
+			Upload:  &api.ModelRepoUpload{SessionID: "session-id", Key: "key"},
+		}, nil
+	}
+	completeModelUploadFile = func(upload *api.ModelRepoUpload, artifactPath string, progress modelUploadProgress) error {
+		return nil
+	}
+	completeModelRepoUpload = func(sessionID string) (*api.CompleteModelRepoUploadResult, error) {
+		return &api.CompleteModelRepoUploadResult{SessionID: sessionID, Status: "completed"}, nil
+	}
+	getModelsForAdd = func(input *api.GetModelsInput) ([]*api.Model, error) {
+		return []*api.Model{{
+			ID:       "model-id",
+			Owner:    "user-id",
+			Name:     "test-model",
+			Provider: "LOCAL",
+			Versions: []*api.ModelVersion{{UUID: "version-uuid", Hash: "hash-123"}},
+		}}, nil
+	}
+
+	cmd := newTestAddModelCommand()
+	stdout, _ := captureStdStreams(t, func() {
+		runAddModel(cmd, nil)
+	})
+
+	var output modelAddOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if output.Model == nil {
+		t.Fatal("expected output model")
+	}
+	if output.Model.Provider != "LOCAL" {
+		t.Fatalf("expected output model provider LOCAL, got %q", output.Model.Provider)
+	}
+	if output.ModelURL != "https://local/user-id/test-model:hash-123" {
+		t.Fatalf("expected local model url, got %q", output.ModelURL)
+	}
+	if output.ModelHash != "hash-123" {
+		t.Fatalf("expected model hash, got %q", output.ModelHash)
+	}
+	if len(output.UploadedFiles) != 1 {
+		t.Fatalf("expected uploaded file details, got %#v", output.UploadedFiles)
+	}
+}
+
+func TestRunAddModelNonUploadLeavesProviderUnset(t *testing.T) {
+	resetAddModelGlobals(t)
+	oldAddModelToRepo := addModelToRepo
+	oldCreateModelRepoUpload := createModelRepoUpload
+	t.Cleanup(func() {
+		addModelToRepo = oldAddModelToRepo
+		createModelRepoUpload = oldCreateModelRepoUpload
+	})
+
+	addModelOwner = "user-id"
+	addModelName = "remote-model"
+
+	var addInput *api.AddModelToRepoInput
+	addModelToRepo = func(input *api.AddModelToRepoInput) (*api.Model, error) {
+		copy := *input
+		addInput = &copy
+		return &api.Model{
+			ID:       "model-id",
+			Owner:    "user-id",
+			Name:     "remote-model",
+			Provider: "huggingface",
+		}, nil
+	}
+	createModelRepoUpload = func(input *api.CreateModelRepoUploadInput) (*api.ModelRepoMutationResult, error) {
+		t.Fatal("non-upload model add must not create an upload session")
+		return nil, nil
+	}
+
+	cmd := newTestAddModelCommand()
+	stdout, _ := captureStdStreams(t, func() {
+		runAddModel(cmd, nil)
+	})
+
+	if addInput == nil {
+		t.Fatal("expected addModelToRepo to be called")
+	}
+	if addInput.Provider != "" {
+		t.Fatalf("expected non-upload provider to be unset, got %q", addInput.Provider)
+	}
+
+	var output modelAddOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if output.Model == nil || output.Model.Provider != "huggingface" {
+		t.Fatalf("expected existing provider in output to be preserved, got %#v", output.Model)
+	}
+	if output.Upload != nil || len(output.UploadedFiles) != 0 || output.ModelURL != "" {
+		t.Fatalf("expected non-upload output only, got %#v", output)
+	}
+}
+
 func TestUploadModelFilesUsesModelVersionUUIDAfterFirstFile(t *testing.T) {
 	oldCreateModelRepoUpload := createModelRepoUpload
 	oldCompleteModelUploadFile := completeModelUploadFile
@@ -120,7 +355,7 @@ func TestUploadModelFilesUsesModelVersionUUIDAfterFirstFile(t *testing.T) {
 	}
 	var events []string
 	var uploadedArtifacts []string
-	completeModelUploadFile = func(upload *api.ModelRepoUpload, artifactPath string) error {
+	completeModelUploadFile = func(upload *api.ModelRepoUpload, artifactPath string, progress modelUploadProgress) error {
 		events = append(events, "upload:"+artifactPath)
 		uploadedArtifacts = append(uploadedArtifacts, artifactPath)
 		return nil
@@ -135,9 +370,15 @@ func TestUploadModelFilesUsesModelVersionUUIDAfterFirstFile(t *testing.T) {
 		}, nil
 	}
 
-	uploadedFiles, err := uploadModelFiles(files, &api.CreateModelRepoUploadInput{Name: "test-model"})
+	uploadedFiles, uploadModel, modelVersionUUID, err := uploadModelFiles(files, &api.CreateModelRepoUploadInput{Name: "test-model"})
 	if err != nil {
 		t.Fatalf("uploadModelFiles returned error: %v", err)
+	}
+	if uploadModel != nil {
+		t.Fatalf("expected upload model to be nil, got %#v", uploadModel)
+	}
+	if modelVersionUUID != "version-uuid" {
+		t.Fatalf("expected model version uuid %q, got %q", "version-uuid", modelVersionUUID)
 	}
 
 	if len(calls) != len(files) {
@@ -197,6 +438,263 @@ func TestUploadModelFilesUsesModelVersionUUIDAfterFirstFile(t *testing.T) {
 	}
 }
 
+type recordingModelUploadProgress struct {
+	bytes    int64
+	finished bool
+	cleared  bool
+}
+
+func (p *recordingModelUploadProgress) Add64(n int64) error {
+	p.bytes += n
+	return nil
+}
+
+func (p *recordingModelUploadProgress) Finish() error {
+	p.finished = true
+	return nil
+}
+
+func (p *recordingModelUploadProgress) Clear() error {
+	p.cleared = true
+	return nil
+}
+
+func TestProgressReaderTracksBytes(t *testing.T) {
+	progress := &recordingModelUploadProgress{}
+	reader := progressReader{
+		reader:   strings.NewReader("abcdef"),
+		progress: progress,
+	}
+
+	if _, err := io.Copy(io.Discard, reader); err != nil {
+		t.Fatalf("copy progress reader: %v", err)
+	}
+	if progress.bytes != 6 {
+		t.Fatalf("expected 6 progress bytes, got %d", progress.bytes)
+	}
+}
+
+func TestPrintCompletedModelUploadSizeWritesToStderr(t *testing.T) {
+	stdout, stderr := captureStdStreams(t, func() {
+		printCompletedModelUploadSize(123)
+	})
+
+	if stdout != "" {
+		t.Fatalf("stdout must remain empty, got %q", stdout)
+	}
+	if stderr != "model size: 123 bytes\n" {
+		t.Fatalf("expected model size on stderr, got %q", stderr)
+	}
+}
+
+func TestWaitForUploadedModelHashPollsUntilHash(t *testing.T) {
+	oldGetModelsForAdd := getModelsForAdd
+	oldSleepModelHashPoll := sleepModelHashPoll
+	t.Cleanup(func() {
+		getModelsForAdd = oldGetModelsForAdd
+		sleepModelHashPoll = oldSleepModelHashPoll
+	})
+
+	var calls int
+	getModelsForAdd = func(input *api.GetModelsInput) ([]*api.Model, error) {
+		calls++
+		if input == nil || input.Name != "test-model" {
+			t.Fatalf("expected model lookup by name test-model, got %#v", input)
+		}
+		if calls == 1 {
+			return []*api.Model{
+				{
+					ID:       "model-id",
+					Owner:    "user-id",
+					Name:     "test-model",
+					Versions: []*api.ModelVersion{{UUID: "version-uuid", Hash: ""}, {UUID: "old-version", Hash: "old-hash"}},
+				},
+			}, nil
+		}
+		return []*api.Model{
+			{
+				ID:       "model-id",
+				Owner:    "user-id",
+				Name:     "test-model",
+				Versions: []*api.ModelVersion{{UUID: "old-version", Hash: "old-hash"}, {UUID: "version-uuid", Hash: "hash-123"}},
+			},
+		}, nil
+	}
+
+	var sleeps []time.Duration
+	sleepModelHashPoll = func(ctx context.Context, duration time.Duration) error {
+		sleeps = append(sleeps, duration)
+		return nil
+	}
+
+	var ready *modelReadyOutput
+	stdout, stderr := captureStdStreams(t, func() {
+		var err error
+		ready, err = waitForUploadedModelHash(context.Background(), "", "test-model", &api.Model{ID: "model-id"}, "version-uuid", 123*time.Millisecond)
+		if err != nil {
+			t.Fatalf("waitForUploadedModelHash returned error: %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Fatalf("stdout must remain empty, got %q", stdout)
+	}
+	if stderr != "waiting for model to be hashed.\n" {
+		t.Fatalf("expected wait progress on stderr, got %q", stderr)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 model lookup calls, got %d", calls)
+	}
+	if len(sleeps) != 1 || sleeps[0] != 123*time.Millisecond {
+		t.Fatalf("expected one 123ms sleep, got %#v", sleeps)
+	}
+	if ready == nil {
+		t.Fatal("expected ready output")
+	}
+	if ready.Owner != "user-id" {
+		t.Fatalf("expected owner user-id, got %q", ready.Owner)
+	}
+	if ready.Name != "test-model" {
+		t.Fatalf("expected name test-model, got %q", ready.Name)
+	}
+	if ready.ModelHash != "hash-123" {
+		t.Fatalf("expected hash hash-123, got %q", ready.ModelHash)
+	}
+	if ready.ModelURL != "https://local/user-id/test-model:hash-123" {
+		t.Fatalf("expected model url, got %q", ready.ModelURL)
+	}
+}
+
+func TestWaitForUploadedModelHashTimesOut(t *testing.T) {
+	oldGetModelsForAdd := getModelsForAdd
+	oldSleepModelHashPoll := sleepModelHashPoll
+	t.Cleanup(func() {
+		getModelsForAdd = oldGetModelsForAdd
+		sleepModelHashPoll = oldSleepModelHashPoll
+	})
+
+	getModelsForAdd = func(input *api.GetModelsInput) ([]*api.Model, error) {
+		return []*api.Model{{
+			ID:       "model-id",
+			Owner:    "user-id",
+			Name:     "test-model",
+			Versions: []*api.ModelVersion{{UUID: "version-uuid", Hash: ""}},
+		}}, nil
+	}
+	sleepModelHashPoll = waitModelHashPoll
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+
+	_, err := waitForUploadedModelHash(ctx, "user-id", "test-model", &api.Model{ID: "model-id"}, "version-uuid", time.Hour)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for model hash") {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
+func TestWaitForUploadedModelHashRequiresModelVersionUUID(t *testing.T) {
+	oldGetModelsForAdd := getModelsForAdd
+	t.Cleanup(func() {
+		getModelsForAdd = oldGetModelsForAdd
+	})
+
+	getModelsForAdd = func(input *api.GetModelsInput) ([]*api.Model, error) {
+		t.Fatal("waitForUploadedModelHash must not poll without a model version uuid")
+		return nil, nil
+	}
+
+	_, err := waitForUploadedModelHash(context.Background(), "user-id", "test-model", &api.Model{ID: "model-id"}, " ", time.Millisecond)
+	if err == nil {
+		t.Fatal("expected missing model version uuid error")
+	}
+	if !strings.Contains(err.Error(), "model version uuid is required to wait for hashing") {
+		t.Fatalf("expected missing model version uuid error, got %v", err)
+	}
+}
+
+func TestUploadedModelVersionHashRequiresMatchingVersionUUID(t *testing.T) {
+	model := &api.Model{Versions: []*api.ModelVersion{
+		{UUID: "old-version", Hash: "old-hash"},
+		{UUID: "version-uuid", Hash: ""},
+		{UUID: "newer-version", Hash: "newer-hash"},
+	}}
+
+	if got := uploadedModelVersionHash(model, ""); got != "" {
+		t.Fatalf("expected no fallback hash without model version uuid, got %q", got)
+	}
+
+	if got := uploadedModelVersionHash(model, "version-uuid"); got != "" {
+		t.Fatalf("expected no hash for pending uploaded version, got %q", got)
+	}
+
+	model.Versions[1].Hash = "hash-123"
+	if got := uploadedModelVersionHash(model, "version-uuid"); got != "hash-123" {
+		t.Fatalf("expected uploaded version hash, got %q", got)
+	}
+}
+
+func TestPrintModelReadyURLWritesToStderr(t *testing.T) {
+	stdout, stderr := captureStdStreams(t, func() {
+		printModelReadyURL(`https://local/user/model:$hash"quoted`)
+	})
+
+	if stdout != "" {
+		t.Fatalf("stdout must remain empty, got %q", stdout)
+	}
+	want := "model is ready to deploy, your model url is: \"https://local/user/model:\\$hash\\\"quoted\"\n"
+	if stderr != want {
+		t.Fatalf("expected ready message on stderr, got %q", stderr)
+	}
+}
+
+func TestCompleteModelUploadWithProgressTracksMultipartBytes(t *testing.T) {
+	artifactPath := filepath.Join(t.TempDir(), "model.bin")
+	if err := os.WriteFile(artifactPath, []byte("abcdef"), 0600); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	var uploadedBytes int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read upload body: %v", err)
+			}
+			uploadedBytes += int64(len(body))
+			w.Header().Set("ETag", `"etag"`)
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPost:
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	progress := &recordingModelUploadProgress{}
+	err := completeModelUploadWithProgress(&api.ModelRepoUpload{
+		PartSizeBytes: 3,
+		CompleteURL:   server.URL,
+		Parts: []*api.ModelRepoUploadPart{
+			{PartNumber: 2, URL: server.URL},
+			{PartNumber: 1, URL: server.URL},
+		},
+	}, artifactPath, progress)
+	if err != nil {
+		t.Fatalf("complete upload: %v", err)
+	}
+	if uploadedBytes != 6 {
+		t.Fatalf("expected server to receive 6 bytes, got %d", uploadedBytes)
+	}
+	if progress.bytes != 6 {
+		t.Fatalf("expected progress to receive 6 bytes, got %d", progress.bytes)
+	}
+}
+
 func TestCompleteModelUploadAllowsZeroByteFileWithNoParts(t *testing.T) {
 	artifactPath := filepath.Join(t.TempDir(), "empty.bin")
 	if err := os.WriteFile(artifactPath, nil, 0600); err != nil {
@@ -207,4 +705,63 @@ func TestCompleteModelUploadAllowsZeroByteFileWithNoParts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected zero-byte upload with no parts to succeed, got %v", err)
 	}
+}
+
+func newTestAddModelCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "add"}
+	cmd.Flags().String("output", "json", "")
+	return cmd
+}
+
+func resetAddModelGlobals(t *testing.T) {
+	t.Helper()
+
+	oldOwner := addModelOwner
+	oldName := addModelName
+	oldCredentialReference := addModelCredentialReference
+	oldCredentialType := addModelCredentialType
+	oldStatus := addModelStatus
+	oldCreateUpload := addModelCreateUpload
+	oldFileName := addModelFileName
+	oldFileSize := addModelFileSize
+	oldPartSize := addModelPartSize
+	oldContentType := addModelContentType
+	oldDirectoryPath := addModelDirectoryPath
+	oldMetadata := addModelMetadata
+	oldWaitForHash := addModelWaitForHash
+	oldHashTimeout := addModelHashTimeout
+	oldVerbose := addModelVerbose
+	t.Cleanup(func() {
+		addModelOwner = oldOwner
+		addModelName = oldName
+		addModelCredentialReference = oldCredentialReference
+		addModelCredentialType = oldCredentialType
+		addModelStatus = oldStatus
+		addModelCreateUpload = oldCreateUpload
+		addModelFileName = oldFileName
+		addModelFileSize = oldFileSize
+		addModelPartSize = oldPartSize
+		addModelContentType = oldContentType
+		addModelDirectoryPath = oldDirectoryPath
+		addModelMetadata = oldMetadata
+		addModelWaitForHash = oldWaitForHash
+		addModelHashTimeout = oldHashTimeout
+		addModelVerbose = oldVerbose
+	})
+
+	addModelOwner = ""
+	addModelName = ""
+	addModelCredentialReference = ""
+	addModelCredentialType = ""
+	addModelStatus = ""
+	addModelCreateUpload = false
+	addModelFileName = ""
+	addModelFileSize = ""
+	addModelPartSize = ""
+	addModelContentType = ""
+	addModelDirectoryPath = ""
+	addModelMetadata = nil
+	addModelWaitForHash = false
+	addModelHashTimeout = modelHashWaitTimeout
+	addModelVerbose = false
 }

--- a/cmd/model/getModels_test.go
+++ b/cmd/model/getModels_test.go
@@ -64,6 +64,15 @@ func TestModelCommandFlags(t *testing.T) {
 	if addCmd.Flags().Lookup("owner") == nil {
 		t.Fatal("expected model add --owner flag")
 	}
+	if addCmd.Flags().Lookup("wait-for-hash") == nil {
+		t.Fatal("expected model add --wait-for-hash flag")
+	}
+	if addCmd.Flags().Lookup("hash-timeout") == nil {
+		t.Fatal("expected model add --hash-timeout flag")
+	}
+	if addCmd.Flags().Lookup("verbose") == nil {
+		t.Fatal("expected model add --verbose flag")
+	}
 	if addCmd.Flags().Lookup("version-status") != nil {
 		t.Fatal("did not expect model add --version-status flag")
 	}

--- a/cmd/model/removeModel.go
+++ b/cmd/model/removeModel.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/runpod/runpodctl/api"
 	"github.com/runpod/runpodctl/internal/output"
@@ -10,8 +11,16 @@ import (
 )
 
 var (
-	removeOwner string
-	removeName  string
+	removeOwner   string
+	removeName    string
+	removeHash    string
+	removeVersion string
+)
+
+var (
+	getModelForRemove                    = api.GetModel
+	removeModelFromRepo                  = api.RemoveModel
+	updateModelVersionStatusByIdentifier = api.UpdateModelVersionStatusByIdentifier
 )
 
 var removeCmd = &cobra.Command{
@@ -44,6 +53,8 @@ func init() {
 func bindRemoveModelFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&removeOwner, "owner", "", "model owner")
 	cmd.Flags().StringVar(&removeName, "name", "", "model name")
+	cmd.Flags().StringVar(&removeHash, "hash", "", "model version hash to remove")
+	cmd.Flags().StringVar(&removeVersion, "version", "", "model version uuid to remove")
 }
 
 func runRemoveModel(cmd *cobra.Command, args []string) {
@@ -52,12 +63,25 @@ func runRemoveModel(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	input := &api.RemoveModelInput{
-		Owner: removeOwner,
-		Name:  removeName,
+	hash := strings.TrimSpace(removeHash)
+	version := strings.TrimSpace(removeVersion)
+	if hash != "" && version != "" {
+		cobra.CheckErr(fmt.Errorf("only one of --hash or --version can be provided"))
+		return
 	}
 
-	result, err := api.RemoveModel(input)
+	var result *api.ModelRepoMutationResult
+	var err error
+	if hash != "" || version != "" {
+		result, err = removeModelVersion(removeOwner, removeName, hash, version)
+	} else {
+		input := &api.RemoveModelInput{
+			Owner: removeOwner,
+			Name:  removeName,
+		}
+		result, err = removeModelFromRepo(input)
+	}
+
 	if err != nil {
 		if handleModelRepoError(err) {
 			return
@@ -69,4 +93,79 @@ func runRemoveModel(cmd *cobra.Command, args []string) {
 
 	format := output.ParseFormat(cmd.Flag("output").Value.String())
 	cobra.CheckErr(output.Print(result, &output.Config{Format: format}))
+}
+
+func removeModelVersion(owner, name, hash, version string) (*api.ModelRepoMutationResult, error) {
+	model, err := getModelForRemove(&api.GetModelInput{
+		Owner: owner,
+		Name:  name,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	target := findModelVersion(model, hash, version)
+	if target == nil {
+		if hash != "" {
+			return nil, fmt.Errorf("model version hash %q not found for %s/%s", hash, owner, name)
+		}
+		return nil, fmt.Errorf("model version %q not found for %s/%s", version, owner, name)
+	}
+
+	input := &api.UpdateModelVersionStatusInput{
+		Status: api.ModelVersionStatusPodRemoved,
+	}
+	if hash != "" {
+		input.Hash = target.Hash
+		if input.Hash == "" {
+			input.Hash = target.VersionHash
+		}
+	} else {
+		input.UUID = target.UUID
+	}
+
+	updatedVersion, err := updateModelVersionStatusByIdentifier(input)
+	if err != nil {
+		return nil, err
+	}
+	patchModelVersion(model, target, updatedVersion)
+
+	return &api.ModelRepoMutationResult{
+		Success: true,
+		Model:   model,
+		Version: updatedVersion,
+	}, nil
+}
+
+func findModelVersion(model *api.Model, hash, version string) *api.ModelVersion {
+	if model == nil {
+		return nil
+	}
+
+	for _, modelVersion := range model.Versions {
+		if modelVersion == nil {
+			continue
+		}
+		if hash != "" && (modelVersion.Hash == hash || modelVersion.VersionHash == hash) {
+			return modelVersion
+		}
+		if version != "" && modelVersion.UUID == version {
+			return modelVersion
+		}
+	}
+
+	return nil
+}
+
+func patchModelVersion(model *api.Model, target, updated *api.ModelVersion) {
+	if model == nil || target == nil || updated == nil {
+		return
+	}
+
+	for i, modelVersion := range model.Versions {
+		if modelVersion == target {
+			model.Versions[i] = updated
+			return
+		}
+	}
 }

--- a/cmd/model/removeModel_test.go
+++ b/cmd/model/removeModel_test.go
@@ -1,0 +1,128 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/runpod/runpodctl/api"
+)
+
+func TestFindModelVersion(t *testing.T) {
+	model := &api.Model{
+		Versions: []*api.ModelVersion{
+			nil,
+			{UUID: "version-uuid", Hash: "version-hash"},
+			{UUID: "other-uuid", VersionHash: "legacy-version-hash"},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		hash    string
+		version string
+		want    string
+	}{
+		{name: "hash", hash: "version-hash", want: "version-uuid"},
+		{name: "version hash", hash: "legacy-version-hash", want: "other-uuid"},
+		{name: "uuid", version: "version-uuid", want: "version-uuid"},
+		{name: "missing", hash: "missing", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findModelVersion(model, tt.hash, tt.version)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("expected nil version, got %#v", got)
+				}
+				return
+			}
+			if got == nil || got.UUID != tt.want {
+				t.Fatalf("expected version %q, got %#v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestRemoveModelVersionUpdatesTargetVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    *api.Model
+		hash     string
+		version  string
+		wantHash string
+		wantUUID string
+	}{
+		{
+			name: "hash uses canonical target hash",
+			model: &api.Model{
+				Owner: "owner",
+				Name:  "name",
+				Versions: []*api.ModelVersion{
+					{UUID: "version-uuid", Hash: "canonical-hash", VersionHash: "version-hash"},
+				},
+			},
+			hash:     "version-hash",
+			wantHash: "canonical-hash",
+		},
+		{
+			name: "hash falls back to target version hash",
+			model: &api.Model{
+				Owner: "owner",
+				Name:  "name",
+				Versions: []*api.ModelVersion{
+					{UUID: "version-uuid", VersionHash: "version-hash"},
+				},
+			},
+			hash:     "version-hash",
+			wantHash: "version-hash",
+		},
+		{
+			name: "version uses target uuid",
+			model: &api.Model{
+				Owner: "owner",
+				Name:  "name",
+				Versions: []*api.ModelVersion{
+					{UUID: "version-uuid", Hash: "version-hash"},
+				},
+			},
+			version:  "version-uuid",
+			wantUUID: "version-uuid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalGet := getModelForRemove
+			originalUpdate := updateModelVersionStatusByIdentifier
+			t.Cleanup(func() {
+				getModelForRemove = originalGet
+				updateModelVersionStatusByIdentifier = originalUpdate
+			})
+
+			getModelForRemove = func(input *api.GetModelInput) (*api.Model, error) {
+				if input.Owner != "owner" || input.Name != "name" {
+					t.Fatalf("unexpected get input: %#v", input)
+				}
+				return tt.model, nil
+			}
+
+			updateModelVersionStatusByIdentifier = func(input *api.UpdateModelVersionStatusInput) (*api.ModelVersion, error) {
+				if input.Hash != tt.wantHash || input.UUID != tt.wantUUID || input.Status != api.ModelVersionStatusPodRemoved {
+					t.Fatalf("unexpected update input: %#v", input)
+				}
+				return &api.ModelVersion{UUID: "version-uuid", Hash: "version-hash", Status: api.ModelVersionStatusPodRemoved}, nil
+			}
+
+			result, err := removeModelVersion("owner", "name", tt.hash, tt.version)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !result.Success || result.Version == nil || result.Version.Status != api.ModelVersionStatusPodRemoved {
+				t.Fatalf("unexpected result: %#v", result)
+			}
+			if result.Model == nil || len(result.Model.Versions) != 1 || result.Model.Versions[0].Status != api.ModelVersionStatusPodRemoved {
+				t.Fatalf("expected returned model version status to be patched, got %#v", result.Model)
+			}
+		})
+	}
+}

--- a/docs/runpodctl_model_add.md
+++ b/docs/runpodctl_model_add.md
@@ -19,6 +19,7 @@ runpodctl model add [flags]
       --credential-type string        credential type (if required)
       --file-name string              file name for upload
       --file-size string              file size in bytes
+      --hash-timeout duration         maximum duration to wait for --wait-for-hash (0 disables timeout) (default 30m0s)
   -h, --help                          help for add
       --metadata stringToString       metadata key=value pairs (default [])
       --model-path string             directory containing model files to upload
@@ -26,6 +27,8 @@ runpodctl model add [flags]
       --name string                   model name
       --owner string                  model owner namespace (user or team owner id)
       --part-size string              multipart upload part size in bytes
+  -v, --verbose                       include upload details in wait-for-hash output
+      --wait-for-hash                 wait for completed model-path uploads to be hashed
 ```
 
 ### Options inherited from parent commands
@@ -37,4 +40,3 @@ runpodctl model add [flags]
 ### SEE ALSO
 
 * [runpodctl model](runpodctl_model.md)	 - manage model repository
-

--- a/docs/runpodctl_model_remove.md
+++ b/docs/runpodctl_model_remove.md
@@ -14,8 +14,10 @@ runpodctl model remove [flags]
 
 ```
   -h, --help           help for remove
+      --hash string    model version hash to remove
       --name string    model name
       --owner string   model owner
+      --version string   model version uuid to remove
 ```
 
 ### Options inherited from parent commands

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"runtime"
 	"time"
 
 	"github.com/runpod/runpodctl/internal/agent"
+	"github.com/runpod/runpodctl/internal/configenv"
 	"github.com/spf13/viper"
 )
 
@@ -38,18 +38,12 @@ type Client struct {
 
 // NewClient creates a new REST API client
 func NewClient() (*Client, error) {
-	apiKey := os.Getenv("RUNPOD_API_KEY")
-	if apiKey == "" {
-		apiKey = viper.GetString("apiKey")
-	}
+	apiKey := configenv.APIKey()
 	if apiKey == "" {
 		return nil, fmt.Errorf("api key not configured. get your key at https://www.runpod.io/console/user/settings then: export RUNPOD_API_KEY=your-key OR run: runpodctl doctor")
 	}
 
-	baseURL := os.Getenv("RUNPOD_API_URL")
-	if baseURL == "" {
-		baseURL = viper.GetString("restApiUrl")
-	}
+	baseURL := configenv.RESTURL()
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/runpod/runpodctl/internal/agent"
+	"github.com/spf13/viper"
 )
 
 func TestNewClient_NoAPIKey(t *testing.T) {
@@ -30,6 +31,27 @@ func TestNewClient_WithEnvKey(t *testing.T) {
 	}
 	if client == nil {
 		t.Error("expected client to be created")
+	}
+}
+
+func TestNewClientEnvOverridesConfig(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("apiKey", "config-key")
+	viper.Set("restApiUrl", "https://config.example.test")
+	t.Setenv("RUNPOD_API_KEY", "env-key")
+	t.Setenv("RUNPOD_API_URL", "https://env.example.test")
+
+	client, err := NewClient()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.apiKey != "env-key" {
+		t.Fatalf("expected env api key, got %q", client.apiKey)
+	}
+	if client.baseURL != "https://env.example.test" {
+		t.Fatalf("expected env rest url, got %q", client.baseURL)
 	}
 }
 
@@ -145,6 +167,53 @@ func TestClient_ErrorResponse(t *testing.T) {
 	_, err = client.Get("/notfound", nil)
 	if err == nil {
 		t.Error("expected error for 404 response")
+	}
+}
+
+func TestClientGraphQLRequestEnvOverridesConfig(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	configHit := false
+	configServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		configHit = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer configServer.Close()
+	viper.Set("apiUrl", configServer.URL)
+
+	graphqlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"myself": map[string]interface{}{
+					"id":                "user-1",
+					"email":             "test@example.com",
+					"clientBalance":     1,
+					"currentSpendPerHr": 0,
+					"spendLimit":        10,
+				},
+			},
+		})
+	}))
+	defer graphqlServer.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", graphqlServer.URL)
+
+	client := &Client{
+		baseURL:    "https://rest.example.test",
+		apiKey:     "test-key",
+		httpClient: graphqlServer.Client(),
+		userAgent:  "test",
+	}
+
+	user, err := client.GetUser()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if user.ID != "user-1" {
+		t.Fatalf("unexpected user id: %q", user.ID)
+	}
+	if configHit {
+		t.Fatal("expected RUNPOD_GRAPHQL_URL to override configured apiUrl")
 	}
 }
 

--- a/internal/api/gpu.go
+++ b/internal/api/gpu.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spf13/viper"
+	"github.com/runpod/runpodctl/internal/configenv"
 )
 
 // GpuType represents a GPU type
@@ -53,7 +53,7 @@ type User struct {
 
 // graphqlRequest makes a GraphQL request
 func (c *Client) graphqlRequest(query string, variables map[string]interface{}) ([]byte, error) {
-	apiURL := viper.GetString("apiUrl")
+	apiURL := configenv.GraphQLURL()
 	if apiURL == "" {
 		apiURL = "https://api.runpod.io/graphql"
 	}

--- a/internal/api/graphql.go
+++ b/internal/api/graphql.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
+	"github.com/runpod/runpodctl/internal/configenv"
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh"
 )
@@ -34,18 +34,12 @@ type GraphQLInput struct {
 
 // NewGraphQLClient creates a new GraphQL client
 func NewGraphQLClient() (*GraphQLClient, error) {
-	apiKey := os.Getenv("RUNPOD_API_KEY")
-	if apiKey == "" {
-		apiKey = viper.GetString("apiKey")
-	}
+	apiKey := configenv.APIKey()
 	if apiKey == "" {
 		return nil, fmt.Errorf("api key not found. run 'runpodctl config --apiKey=xxx' or set RUNPOD_API_KEY")
 	}
 
-	apiURL := os.Getenv("RUNPOD_GRAPHQL_URL")
-	if apiURL == "" {
-		apiURL = viper.GetString("apiUrl")
-	}
+	apiURL := configenv.GraphQLURL()
 	if apiURL == "" {
 		apiURL = DefaultGraphQLURL
 	}
@@ -299,28 +293,28 @@ type PodEnvVar struct {
 
 // CreatePodGQLInput is the input for creating a pod via GraphQL
 type CreatePodGQLInput struct {
-	CloudType         string       `json:"cloudType,omitempty"`
-	ContainerDiskInGb int          `json:"containerDiskInGb"`
-	DataCenterId      string       `json:"dataCenterId,omitempty"`
-	Env               []*PodEnvVar `json:"env,omitempty"`
-	GpuCount          int          `json:"gpuCount"`
-	GpuTypeId         string       `json:"gpuTypeId,omitempty"`
-	ImageName         string       `json:"imageName,omitempty"`
-	Name              string       `json:"name,omitempty"`
-	Ports             string       `json:"ports,omitempty"`
-	StartSsh          bool         `json:"startSsh"`
-	SupportPublicIp   bool         `json:"supportPublicIp,omitempty"`
-	TemplateId        string       `json:"templateId,omitempty"`
-	VolumeInGb        int          `json:"volumeInGb,omitempty"`
-	VolumeMountPath   string       `json:"volumeMountPath,omitempty"`
-	NetworkVolumeId   string       `json:"networkVolumeId,omitempty"`
-	MinCudaVersion         string       `json:"minCudaVersion,omitempty"`
-	DockerArgs             string       `json:"dockerArgs,omitempty"`
-	ContainerRegistryAuthId string     `json:"containerRegistryAuthId,omitempty"`
-	CountryCode            string       `json:"countryCode,omitempty"`
-	StopAfter              string       `json:"stopAfter,omitempty"`
-	TerminateAfter         string       `json:"terminateAfter,omitempty"`
-	Compliance             []string     `json:"compliance,omitempty"`
+	CloudType               string       `json:"cloudType,omitempty"`
+	ContainerDiskInGb       int          `json:"containerDiskInGb"`
+	DataCenterId            string       `json:"dataCenterId,omitempty"`
+	Env                     []*PodEnvVar `json:"env,omitempty"`
+	GpuCount                int          `json:"gpuCount"`
+	GpuTypeId               string       `json:"gpuTypeId,omitempty"`
+	ImageName               string       `json:"imageName,omitempty"`
+	Name                    string       `json:"name,omitempty"`
+	Ports                   string       `json:"ports,omitempty"`
+	StartSsh                bool         `json:"startSsh"`
+	SupportPublicIp         bool         `json:"supportPublicIp,omitempty"`
+	TemplateId              string       `json:"templateId,omitempty"`
+	VolumeInGb              int          `json:"volumeInGb,omitempty"`
+	VolumeMountPath         string       `json:"volumeMountPath,omitempty"`
+	NetworkVolumeId         string       `json:"networkVolumeId,omitempty"`
+	MinCudaVersion          string       `json:"minCudaVersion,omitempty"`
+	DockerArgs              string       `json:"dockerArgs,omitempty"`
+	ContainerRegistryAuthId string       `json:"containerRegistryAuthId,omitempty"`
+	CountryCode             string       `json:"countryCode,omitempty"`
+	StopAfter               string       `json:"stopAfter,omitempty"`
+	TerminateAfter          string       `json:"terminateAfter,omitempty"`
+	Compliance              []string     `json:"compliance,omitempty"`
 }
 
 // CreatePod creates a pod via GraphQL (podFindAndDeployOnDemand)

--- a/internal/api/graphql_test.go
+++ b/internal/api/graphql_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 func TestSSHKeyMatches(t *testing.T) {
@@ -44,6 +46,27 @@ func TestSplitSSHKeyBlock(t *testing.T) {
 	}
 	if keys[1] != "ssh-rsa bbb second" {
 		t.Fatalf("unexpected second key: %q", keys[1])
+	}
+}
+
+func TestNewGraphQLClientEnvOverridesConfig(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("apiKey", "config-key")
+	viper.Set("apiUrl", "https://config.example.test/graphql")
+	t.Setenv("RUNPOD_API_KEY", "env-key")
+	t.Setenv("RUNPOD_GRAPHQL_URL", "https://env.example.test/graphql")
+
+	client, err := NewGraphQLClient()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.apiKey != "env-key" {
+		t.Fatalf("expected env api key, got %q", client.apiKey)
+	}
+	if client.url != "https://env.example.test/graphql" {
+		t.Fatalf("expected env graphql url, got %q", client.url)
 	}
 }
 

--- a/internal/configenv/configenv.go
+++ b/internal/configenv/configenv.go
@@ -1,0 +1,32 @@
+package configenv
+
+import (
+	"os"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	APIKeyEnv     = "RUNPOD_API_KEY"
+	RESTURLEnv    = "RUNPOD_API_URL"
+	GraphQLURLEnv = "RUNPOD_GRAPHQL_URL"
+)
+
+func APIKey() string {
+	return envOrConfig(APIKeyEnv, "apiKey")
+}
+
+func RESTURL() string {
+	return envOrConfig(RESTURLEnv, "restApiUrl")
+}
+
+func GraphQLURL() string {
+	return envOrConfig(GraphQLURLEnv, "apiUrl")
+}
+
+func envOrConfig(envKey, configKey string) string {
+	if value := os.Getenv(envKey); value != "" {
+		return value
+	}
+	return viper.GetString(configKey)
+}


### PR DESCRIPTION
Fixes issues with env vars not alway overriding config values, and centralizes how we track config values
Adds a progress bar to Model Repo uploads and adds an option to wait until the model is hashed before returning
Allows removing a specific Model version from Model Repo