### PR TITLE
fix: verify self-update archive checksums

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -88,6 +90,57 @@ func assetName() string {
 		ext = ".zip"
 	}
 	return fmt.Sprintf("runpodctl-%s-%s%s", runtime.GOOS, arch, ext)
+}
+
+func checksumAssetName(version string) string {
+	return fmt.Sprintf("checksums_%s_sha256.txt", strings.TrimPrefix(version, "v"))
+}
+
+func findAsset(assets []Asset, name string) (Asset, bool) {
+	for _, asset := range assets {
+		if asset.Name == name {
+			return asset, true
+		}
+	}
+	return Asset{}, false
+}
+
+func checksumForAsset(checksumText []byte, assetName string) (string, error) {
+	for _, line := range strings.Split(string(checksumText), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[1] != assetName {
+			continue
+		}
+		digest := strings.ToLower(fields[0])
+		if len(digest) != sha256.Size*2 {
+			return "", fmt.Errorf("invalid checksum for %s", assetName)
+		}
+		if _, err := hex.DecodeString(digest); err != nil {
+			return "", fmt.Errorf("invalid checksum for %s: %w", assetName, err)
+		}
+		return digest, nil
+	}
+	return "", fmt.Errorf("checksum not found for %s", assetName)
+}
+
+func verifyFileChecksum(path string, expected string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return err
+	}
+
+	actual := hex.EncodeToString(hash.Sum(nil))
+	expected = strings.ToLower(strings.TrimSpace(expected))
+	if actual != expected {
+		return fmt.Errorf("checksum mismatch for %s", filepath.Base(path))
+	}
+	return nil
 }
 
 // extractBinaryFromTarGz extracts the "runpodctl" binary from a .tar.gz archive.

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -248,10 +248,10 @@ var updateCmd = &cobra.Command{
 			return fmt.Errorf("platform %s-%s not supported in latest version", runtime.GOOS, runtime.GOARCH)
 		}
 
-		checksumAssetName := checksumAssetName(latestVersion)
-		checksumAsset, ok := findAsset(apiResp.Assets, checksumAssetName)
+		checksumName := checksumAssetName(latestVersion)
+		checksumAsset, ok := findAsset(apiResp.Assets, checksumName)
 		if !ok {
-			return fmt.Errorf("failed to verify update checksum: checksum asset %s not found", checksumAssetName)
+			return fmt.Errorf("failed to verify update checksum: checksum asset %s not found", checksumName)
 		}
 
 		ex, err := os.Executable()

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -29,7 +29,7 @@ type GithubApiResponse struct {
 	Assets  []Asset `json:"assets"`
 }
 
-func DownloadFile(url string, savePath string) (file *os.File, err error) {
+func DownloadBytes(url string) ([]byte, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
@@ -40,7 +40,11 @@ func DownloadFile(url string, savePath string) (file *os.File, err error) {
 		return nil, fmt.Errorf("bad status: %s", resp.Status)
 	}
 
-	content, err := io.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
+}
+
+func DownloadFile(url string, savePath string) (file *os.File, err error) {
+	content, err := DownloadBytes(url)
 	if err != nil {
 		return nil, err
 	}
@@ -143,6 +147,14 @@ func verifyFileChecksum(path string, expected string) error {
 	return nil
 }
 
+func verifyArchiveChecksum(archivePath string, archiveName string, checksumText []byte) error {
+	expected, err := checksumForAsset(checksumText, archiveName)
+	if err != nil {
+		return err
+	}
+	return verifyFileChecksum(archivePath, expected)
+}
+
 // extractBinaryFromTarGz extracts the "runpodctl" binary from a .tar.gz archive.
 func extractBinaryFromTarGz(archivePath, destPath string) error {
 	f, err := os.Open(archivePath)
@@ -231,15 +243,15 @@ var updateCmd = &cobra.Command{
 
 		// find download link for current platform
 		expectedAsset := assetName()
-		var downloadLink string
-		for _, asset := range apiResp.Assets {
-			if asset.Name == expectedAsset {
-				downloadLink = asset.Url
-				break
-			}
-		}
-		if downloadLink == "" {
+		downloadAsset, ok := findAsset(apiResp.Assets, expectedAsset)
+		if !ok {
 			return fmt.Errorf("platform %s-%s not supported in latest version", runtime.GOOS, runtime.GOARCH)
+		}
+
+		checksumAssetName := checksumAssetName(latestVersion)
+		checksumAsset, ok := findAsset(apiResp.Assets, checksumAssetName)
+		if !ok {
+			return fmt.Errorf("failed to verify update checksum: checksum asset %s not found", checksumAssetName)
 		}
 
 		ex, err := os.Executable()
@@ -264,11 +276,19 @@ var updateCmd = &cobra.Command{
 		defer os.Remove(archivePath)
 
 		fmt.Printf("downloading runpodctl %s\n", latestVersion)
-		file, err := DownloadFile(downloadLink, archivePath)
+		file, err := DownloadFile(downloadAsset.Url, archivePath)
 		if err != nil {
 			return fmt.Errorf("failed to fetch the latest version of runpodctl: %w", err)
 		}
 		file.Close()
+
+		checksumText, err := DownloadBytes(checksumAsset.Url)
+		if err != nil {
+			return fmt.Errorf("failed to fetch update checksum: %w", err)
+		}
+		if err := verifyArchiveChecksum(archivePath, expectedAsset, checksumText); err != nil {
+			return fmt.Errorf("failed to verify update checksum: %w", err)
+		}
 
 		// extract binary from archive to a temp location next to the destination
 		extractedPath := destPath + ".new"

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestChecksumAssetName(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "tag with leading v", version: "v2.6.1", want: "checksums_2.6.1_sha256.txt"},
+		{name: "version without leading v", version: "2.6.1", want: "checksums_2.6.1_sha256.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checksumAssetName(tt.version); got != tt.want {
+				t.Fatalf("checksumAssetName(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindAsset(t *testing.T) {
+	assets := []Asset{
+		{Name: "runpodctl-linux-amd64.tar.gz", Url: "https://example.test/archive"},
+		{Name: "checksums_2.6.1_sha256.txt", Url: "https://example.test/checksums"},
+	}
+
+	asset, ok := findAsset(assets, "checksums_2.6.1_sha256.txt")
+	if !ok {
+		t.Fatal("expected checksum asset to be found")
+	}
+	if asset.Url != "https://example.test/checksums" {
+		t.Fatalf("asset.Url = %q, want checksum URL", asset.Url)
+	}
+
+	if _, ok := findAsset(assets, "missing.txt"); ok {
+		t.Fatal("expected missing asset lookup to fail")
+	}
+}
+
+func TestChecksumForAsset(t *testing.T) {
+	const linuxArchive = "runpodctl-linux-amd64.tar.gz"
+	const linuxDigest = "0fbcbfad3706995370b7858ee08ad7faa9579a639d831655b0a7ebe6149782c2"
+	checksumText := []byte(strings.Join([]string{
+		"09001e4666934c338919b00bc5e415259fe93228b5eb56f51c141730d5e5bbee  runpodctl-darwin-all.tar.gz",
+		linuxDigest + "  " + linuxArchive,
+		"a18a5dd9d0ac33f91399bd1d1bca09fbb95b6a82ffb3722f2528e3daee94f50c  runpodctl-windows-amd64.zip",
+	}, "\n"))
+
+	got, err := checksumForAsset(checksumText, linuxArchive)
+	if err != nil {
+		t.Fatalf("checksumForAsset returned error: %v", err)
+	}
+	if got != linuxDigest {
+		t.Fatalf("checksumForAsset digest = %q, want %q", got, linuxDigest)
+	}
+}
+
+func TestChecksumForAssetMissing(t *testing.T) {
+	_, err := checksumForAsset([]byte("09001e4666934c338919b00bc5e415259fe93228b5eb56f51c141730d5e5bbee  runpodctl-darwin-all.tar.gz\n"), "runpodctl-linux-amd64.tar.gz")
+	if err == nil {
+		t.Fatal("expected missing checksum entry to fail")
+	}
+	if !strings.Contains(err.Error(), "checksum not found") {
+		t.Fatalf("expected missing checksum error, got %v", err)
+	}
+}
+
+func TestChecksumForAssetMalformedDigest(t *testing.T) {
+	_, err := checksumForAsset([]byte("not-a-sha  runpodctl-linux-amd64.tar.gz\n"), "runpodctl-linux-amd64.tar.gz")
+	if err == nil {
+		t.Fatal("expected malformed checksum entry to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid checksum") {
+		t.Fatalf("expected invalid checksum error, got %v", err)
+	}
+}
+
+func TestVerifyFileChecksum(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "archive-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("release archive bytes"); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	digest := sha256.Sum256([]byte("release archive bytes"))
+	expected := fmt.Sprintf("%x", digest)
+
+	if err := verifyFileChecksum(file.Name(), expected); err != nil {
+		t.Fatalf("verifyFileChecksum returned error: %v", err)
+	}
+
+	if err := verifyFileChecksum(file.Name(), strings.Repeat("0", 64)); err == nil {
+		t.Fatal("expected checksum mismatch to fail")
+	}
+}

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -107,3 +107,41 @@ func TestVerifyFileChecksum(t *testing.T) {
 		t.Fatal("expected checksum mismatch to fail")
 	}
 }
+
+func TestVerifyArchiveChecksum(t *testing.T) {
+	archive, err := os.CreateTemp(t.TempDir(), "runpodctl-linux-amd64-*.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := archive.WriteString("archive bytes"); err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	digest := sha256.Sum256([]byte("archive bytes"))
+	checksumText := []byte(fmt.Sprintf("%x  runpodctl-linux-amd64.tar.gz\n", digest))
+
+	if err := verifyArchiveChecksum(archive.Name(), "runpodctl-linux-amd64.tar.gz", checksumText); err != nil {
+		t.Fatalf("verifyArchiveChecksum returned error: %v", err)
+	}
+}
+
+func TestVerifyArchiveChecksumFailsWhenEntryMissing(t *testing.T) {
+	archive, err := os.CreateTemp(t.TempDir(), "runpodctl-linux-amd64-*.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	err = verifyArchiveChecksum(archive.Name(), "runpodctl-linux-amd64.tar.gz", []byte("09001e4666934c338919b00bc5e415259fe93228b5eb56f51c141730d5e5bbee  runpodctl-darwin-all.tar.gz\n"))
+	if err == nil {
+		t.Fatal("expected missing checksum to fail")
+	}
+	if !strings.Contains(err.Error(), "checksum not found") {
+		t.Fatalf("expected missing checksum error, got %v", err)
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -163,7 +163,10 @@ verify_download_checksum() {
         return 1
     fi
 
-    actual=$(calculate_sha256 "$archive_path")
+    if ! actual=$(calculate_sha256 "$archive_path"); then
+        echo "Failed to calculate checksum for $ARCHIVE_FILENAME."
+        return 1
+    fi
     expected=$(echo "$expected" | tr '[:upper:]' '[:lower:]')
     actual=$(echo "$actual" | tr '[:upper:]' '[:lower:]')
 

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@
 #   - Internet connection
 #   - Homebrew (for macOS users)
 #   - jq (for JSON processing, will be installed automatically)
+#   - sha256sum on Linux or shasum on macOS (usually preinstalled)
 #
 # Supported Platforms:
 #   - Linux (amd64)
@@ -19,6 +20,10 @@
 
 set -e
 REQUIRED_PKGS=("jq")  # Add all required packages to this list, separated by spaces.
+
+VERSION=""
+DOWNLOAD_URL=""
+ARCHIVE_FILENAME=""
 
 
 # -------------------------------- Check Root -------------------------------- #
@@ -99,7 +104,8 @@ download_url_constructor() {
 
     if [[ "$os_type" == "darwin" ]]; then
         # macOS uses a universal binary (all architectures)
-        DOWNLOAD_URL="https://github.com/runpod/runpodctl/releases/download/${VERSION}/runpodctl-darwin-all.tar.gz"
+        ARCHIVE_FILENAME="runpodctl-darwin-all.tar.gz"
+        DOWNLOAD_URL="https://github.com/runpod/runpodctl/releases/download/${VERSION}/${ARCHIVE_FILENAME}"
         return
     elif [[ "$os_type" == "linux" ]]; then
         if [[ "$arch_type" == "x86_64" ]]; then
@@ -115,16 +121,79 @@ download_url_constructor() {
         exit 1
     fi
 
-    DOWNLOAD_URL="https://github.com/runpod/runpodctl/releases/download/${VERSION}/runpodctl-${os_type}-${arch_type}.tar.gz"
+    ARCHIVE_FILENAME="runpodctl-${os_type}-${arch_type}.tar.gz"
+    DOWNLOAD_URL="https://github.com/runpod/runpodctl/releases/download/${VERSION}/${ARCHIVE_FILENAME}"
+}
+
+# ------------------------------- Checksum Helpers ---------------------------- #
+checksum_file_name() {
+    echo "checksums_${VERSION#v}_sha256.txt"
+}
+
+calculate_sha256() {
+    local file_path=$1
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file_path" | awk '{print $1}'
+        return
+    fi
+
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file_path" | awk '{print $1}'
+        return
+    fi
+
+    echo "No SHA-256 checksum tool found. Install sha256sum or shasum." >&2
+    return 1
+}
+
+checksum_for_archive() {
+    local checksum_path=$1
+    awk -v archive="$ARCHIVE_FILENAME" '$2 == archive { print $1; found=1; exit } END { if (!found) exit 1 }' "$checksum_path"
+}
+
+verify_download_checksum() {
+    local archive_path=$1
+    local checksum_path=$2
+    local expected
+    local actual
+
+    if ! expected=$(checksum_for_archive "$checksum_path"); then
+        echo "Checksum not found for $ARCHIVE_FILENAME."
+        return 1
+    fi
+
+    actual=$(calculate_sha256 "$archive_path")
+    expected=$(echo "$expected" | tr '[:upper:]' '[:lower:]')
+    actual=$(echo "$actual" | tr '[:upper:]' '[:lower:]')
+
+    if [[ "$actual" != "$expected" ]]; then
+        echo "Checksum mismatch for $ARCHIVE_FILENAME."
+        return 1
+    fi
+
+    echo "Checksum verified for $ARCHIVE_FILENAME."
 }
 
 # ---------------------------- Download & Install ---------------------------- #
 download_and_install_cli() {
-    local cli_archive_file_name="runpodctl.tar.gz"
+    local cli_archive_file_name="$ARCHIVE_FILENAME"
+    local checksum_file
+    checksum_file=$(checksum_file_name)
+
     if ! wget -q --progress=bar "$DOWNLOAD_URL" -O "$cli_archive_file_name"; then
         echo "Failed to download $cli_archive_file_name."
         exit 1
     fi
+
+    local checksum_url="https://github.com/runpod/runpodctl/releases/download/${VERSION}/${checksum_file}"
+    if ! wget -q --progress=bar "$checksum_url" -O "$checksum_file"; then
+        echo "Failed to download $checksum_file."
+        exit 1
+    fi
+
+    verify_download_checksum "$cli_archive_file_name" "$checksum_file"
+
     local cli_file_name="runpodctl"
     tar -xzf "$cli_archive_file_name" "$cli_file_name"
     chmod +x "$cli_file_name"
@@ -139,10 +208,16 @@ download_and_install_cli() {
 # ---------------------------------------------------------------------------- #
 #                                     Main                                     #
 # ---------------------------------------------------------------------------- #
-echo "Installing runpodctl..."
+main() {
+    echo "Installing runpodctl..."
 
-check_root
-check_system_requirements
-fetch_latest_version
-download_url_constructor
-download_and_install_cli
+    check_root
+    check_system_requirements
+    fetch_latest_version
+    download_url_constructor
+    download_and_install_cli
+}
+
+if [[ "${RUNPODCTL_INSTALL_TEST:-}" != "1" ]]; then
+    main
+fi

--- a/install.sh
+++ b/install.sh
@@ -179,27 +179,41 @@ verify_download_checksum() {
 download_and_install_cli() {
     local cli_archive_file_name="$ARCHIVE_FILENAME"
     local checksum_file
+    local download_dir
     checksum_file=$(checksum_file_name)
+    download_dir=$(mktemp -d)
 
-    if ! wget -q --progress=bar "$DOWNLOAD_URL" -O "$cli_archive_file_name"; then
+    trap 'rm -rf "$download_dir"; trap - RETURN' RETURN
+
+    local archive_path="$download_dir/$cli_archive_file_name"
+    if ! wget -q --progress=bar "$DOWNLOAD_URL" -O "$archive_path"; then
         echo "Failed to download $cli_archive_file_name."
-        exit 1
+        return 1
     fi
 
+    local checksum_path="$download_dir/$checksum_file"
     local checksum_url="https://github.com/runpod/runpodctl/releases/download/${VERSION}/${checksum_file}"
-    if ! wget -q --progress=bar "$checksum_url" -O "$checksum_file"; then
+    if ! wget -q --progress=bar "$checksum_url" -O "$checksum_path"; then
         echo "Failed to download $checksum_file."
-        exit 1
+        return 1
     fi
 
-    verify_download_checksum "$cli_archive_file_name" "$checksum_file"
+    if ! verify_download_checksum "$archive_path" "$checksum_path"; then
+        return 1
+    fi
 
     local cli_file_name="runpodctl"
-    tar -xzf "$cli_archive_file_name" "$cli_file_name"
-    chmod +x "$cli_file_name"
-    if ! mv "$cli_file_name" /usr/local/bin/; then
+    if ! tar -xzf "$archive_path" -C "$download_dir" "$cli_file_name"; then
+        echo "Failed to extract $cli_file_name from $cli_archive_file_name."
+        return 1
+    fi
+    if ! chmod +x "$download_dir/$cli_file_name"; then
+        echo "Failed to mark $cli_file_name as executable."
+        return 1
+    fi
+    if ! mv "$download_dir/$cli_file_name" /usr/local/bin/; then
         echo "Failed to move $cli_file_name to /usr/local/bin/."
-        exit 1
+        return 1
     fi
     echo "runpodctl installed successfully."
 }

--- a/install_test.sh
+++ b/install_test.sh
@@ -3,12 +3,12 @@ set -euo pipefail
 
 RUNPODCTL_INSTALL_TEST=1 source ./install.sh
 
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+TEST_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
 
 ARCHIVE_FILENAME="runpodctl-linux-amd64.tar.gz"
-ARCHIVE_PATH="$TMPDIR/$ARCHIVE_FILENAME"
-CHECKSUM_PATH="$TMPDIR/checksums.txt"
+ARCHIVE_PATH="$TEST_TMPDIR/$ARCHIVE_FILENAME"
+CHECKSUM_PATH="$TEST_TMPDIR/checksums.txt"
 
 printf 'release archive bytes' > "$ARCHIVE_PATH"
 EXPECTED=$(calculate_sha256 "$ARCHIVE_PATH")
@@ -27,3 +27,149 @@ if verify_download_checksum "$ARCHIVE_PATH" "$CHECKSUM_PATH"; then
     echo "expected missing checksum entry to fail"
     exit 1
 fi
+
+assert_no_installer_artifacts() {
+    local work_dir=$1
+    local leftovers
+
+    leftovers=$(find "$work_dir" -maxdepth 1 \( \
+        -name 'runpodctl-*.tar.gz' -o \
+        -name 'checksums_*_sha256.txt' -o \
+        -name 'runpodctl' \
+    \) -print)
+
+    if [[ -n "$leftovers" ]]; then
+        echo "installer left artifacts in $work_dir:"
+        echo "$leftovers"
+        exit 1
+    fi
+}
+
+run_download_cleanup_success_test() {
+    local work_dir="$TEST_TMPDIR/success-cwd"
+    local installed_dir="$TEST_TMPDIR/success-installed"
+    mkdir -p "$work_dir" "$installed_dir"
+
+    (
+        cd "$work_dir"
+        VERSION="v9.9.9"
+        ARCHIVE_FILENAME="runpodctl-linux-amd64.tar.gz"
+        DOWNLOAD_URL="https://example.test/$ARCHIVE_FILENAME"
+
+        local downloaded_archive_path=""
+        wget() {
+            local output=""
+            while [[ $# -gt 0 ]]; do
+                if [[ "$1" == "-O" ]]; then
+                    output=$2
+                    shift 2
+                    continue
+                fi
+                shift
+            done
+
+            case "${output##*/}" in
+                "$ARCHIVE_FILENAME")
+                    downloaded_archive_path=$output
+                    printf 'release archive bytes' > "$output"
+                    ;;
+                "$(checksum_file_name)")
+                    local digest
+                    digest=$(calculate_sha256 "$downloaded_archive_path")
+                    printf '%s  %s\n' "$digest" "$ARCHIVE_FILENAME" > "$output"
+                    ;;
+                *)
+                    echo "unexpected wget output path: $output" >&2
+                    return 1
+                    ;;
+            esac
+        }
+
+        tar() {
+            local extract_dir="."
+            while [[ $# -gt 0 ]]; do
+                if [[ "$1" == "-C" ]]; then
+                    extract_dir=$2
+                    shift 2
+                    continue
+                fi
+                shift
+            done
+            printf '#!/usr/bin/env sh\n' > "$extract_dir/runpodctl"
+        }
+
+        chmod() {
+            :
+        }
+
+        mv() {
+            command mv "$1" "$installed_dir/"
+        }
+
+        download_and_install_cli >/dev/null
+    )
+
+    assert_no_installer_artifacts "$work_dir"
+    if [[ ! -f "$installed_dir/runpodctl" ]]; then
+        echo "expected runpodctl to be installed"
+        exit 1
+    fi
+}
+
+run_download_cleanup_failure_test() {
+    local work_dir="$TEST_TMPDIR/failure-cwd"
+    mkdir -p "$work_dir"
+
+    set +e
+    (
+        set -e
+        cd "$work_dir"
+        VERSION="v9.9.9"
+        ARCHIVE_FILENAME="runpodctl-linux-amd64.tar.gz"
+        DOWNLOAD_URL="https://example.test/$ARCHIVE_FILENAME"
+
+        wget() {
+            local output=""
+            while [[ $# -gt 0 ]]; do
+                if [[ "$1" == "-O" ]]; then
+                    output=$2
+                    shift 2
+                    continue
+                fi
+                shift
+            done
+
+            case "${output##*/}" in
+                "$ARCHIVE_FILENAME")
+                    printf 'release archive bytes' > "$output"
+                    ;;
+                "$(checksum_file_name)")
+                    printf '%064d  %s\n' 0 "$ARCHIVE_FILENAME" > "$output"
+                    ;;
+                *)
+                    echo "unexpected wget output path: $output" >&2
+                    return 1
+                    ;;
+            esac
+        }
+
+        tar() {
+            echo "tar should not run after checksum failure" >&2
+            return 1
+        }
+
+        download_and_install_cli >/dev/null
+    ) >/dev/null 2>&1
+    local status=$?
+    set -e
+
+    if [[ $status -eq 0 ]]; then
+        echo "expected checksum failure to abort install"
+        exit 1
+    fi
+
+    assert_no_installer_artifacts "$work_dir"
+}
+
+run_download_cleanup_success_test
+run_download_cleanup_failure_test

--- a/install_test.sh
+++ b/install_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNPODCTL_INSTALL_TEST=1 source ./install.sh
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+ARCHIVE_FILENAME="runpodctl-linux-amd64.tar.gz"
+ARCHIVE_PATH="$TMPDIR/$ARCHIVE_FILENAME"
+CHECKSUM_PATH="$TMPDIR/checksums.txt"
+
+printf 'release archive bytes' > "$ARCHIVE_PATH"
+EXPECTED=$(calculate_sha256 "$ARCHIVE_PATH")
+printf '%s  %s\n' "$EXPECTED" "$ARCHIVE_FILENAME" > "$CHECKSUM_PATH"
+
+verify_download_checksum "$ARCHIVE_PATH" "$CHECKSUM_PATH"
+
+printf 'tampered archive bytes' > "$ARCHIVE_PATH"
+if verify_download_checksum "$ARCHIVE_PATH" "$CHECKSUM_PATH"; then
+    echo "expected checksum mismatch to fail"
+    exit 1
+fi
+
+ARCHIVE_FILENAME="missing.tar.gz"
+if verify_download_checksum "$ARCHIVE_PATH" "$CHECKSUM_PATH"; then
+    echo "expected missing checksum entry to fail"
+    exit 1
+fi

--- a/install_test.sh
+++ b/install_test.sh
@@ -126,9 +126,13 @@ run_download_cleanup_success_test() {
     fi
 }
 
-run_download_cleanup_failure_test() {
-    local work_dir="$TEST_TMPDIR/failure-cwd"
-    local expected_download_dir="$TEST_TMPDIR/failure-download"
+run_download_cleanup_calculation_failure_test() {
+    local work_dir="$TEST_TMPDIR/calculation-failure-cwd"
+    local expected_download_dir="$TEST_TMPDIR/calculation-failure-download"
+    local tar_called="$TEST_TMPDIR/calculation-failure-tar-called"
+    local command_output_path="$TEST_TMPDIR/calculation-failure-output"
+    local archive_filename="runpodctl-linux-amd64.tar.gz"
+    local output
     mkdir -p "$work_dir"
 
     set +e
@@ -136,7 +140,7 @@ run_download_cleanup_failure_test() {
         set -e
         cd "$work_dir"
         VERSION="v9.9.9"
-        ARCHIVE_FILENAME="runpodctl-linux-amd64.tar.gz"
+        ARCHIVE_FILENAME="$archive_filename"
         DOWNLOAD_URL="https://example.test/$ARCHIVE_FILENAME"
 
         mktemp() {
@@ -145,42 +149,52 @@ run_download_cleanup_failure_test() {
         }
 
         wget() {
-            local output=""
+            local output_path=""
             while [[ $# -gt 0 ]]; do
                 if [[ "$1" == "-O" ]]; then
-                    output=$2
+                    output_path=$2
                     shift 2
                     continue
                 fi
                 shift
             done
 
-            case "${output##*/}" in
+            case "${output_path##*/}" in
                 "$ARCHIVE_FILENAME")
-                    printf 'release archive bytes' > "$output"
+                    printf 'release archive bytes' > "$output_path"
                     ;;
-                "$(checksum_file_name)")
-                    printf '%064d  %s\n' 0 "$ARCHIVE_FILENAME" > "$output"
+                "checksums_9.9.9_sha256.txt")
+                    printf '%064d  %s\n' 0 "$ARCHIVE_FILENAME" > "$output_path"
                     ;;
                 *)
-                    echo "unexpected wget output path: $output" >&2
+                    echo "unexpected wget output path: $output_path" >&2
                     return 1
                     ;;
             esac
         }
 
-        tar() {
-            echo "tar should not run after checksum failure" >&2
+        calculate_sha256() {
             return 1
         }
 
-        download_and_install_cli >/dev/null
-    ) >/dev/null 2>&1
+        tar() {
+            touch "$tar_called"
+            return 1
+        }
+
+        download_and_install_cli
+    ) > "$command_output_path" 2>&1
     local status=$?
     set -e
+    output=$(<"$command_output_path")
 
     if [[ $status -eq 0 ]]; then
-        echo "expected checksum failure to abort install"
+        echo "expected checksum calculation failure to abort install"
+        exit 1
+    fi
+    if [[ "$output" != *"Failed to calculate checksum for $archive_filename."* ]]; then
+        echo "expected checksum calculation failure message, got:"
+        echo "$output"
         exit 1
     fi
 
@@ -189,7 +203,11 @@ run_download_cleanup_failure_test() {
         echo "installer left download directory $expected_download_dir"
         exit 1
     fi
+    if [[ -e "$tar_called" ]]; then
+        echo "tar ran after checksum calculation failure"
+        exit 1
+    fi
 }
 
 run_download_cleanup_success_test
-run_download_cleanup_failure_test
+run_download_cleanup_calculation_failure_test

--- a/install_test.sh
+++ b/install_test.sh
@@ -48,6 +48,7 @@ assert_no_installer_artifacts() {
 run_download_cleanup_success_test() {
     local work_dir="$TEST_TMPDIR/success-cwd"
     local installed_dir="$TEST_TMPDIR/success-installed"
+    local expected_download_dir="$TEST_TMPDIR/success-download"
     mkdir -p "$work_dir" "$installed_dir"
 
     (
@@ -55,6 +56,11 @@ run_download_cleanup_success_test() {
         VERSION="v9.9.9"
         ARCHIVE_FILENAME="runpodctl-linux-amd64.tar.gz"
         DOWNLOAD_URL="https://example.test/$ARCHIVE_FILENAME"
+
+        mktemp() {
+            mkdir -p "$expected_download_dir"
+            printf '%s\n' "$expected_download_dir"
+        }
 
         local downloaded_archive_path=""
         wget() {
@@ -110,6 +116,10 @@ run_download_cleanup_success_test() {
     )
 
     assert_no_installer_artifacts "$work_dir"
+    if [[ -e "$expected_download_dir" ]]; then
+        echo "installer left download directory $expected_download_dir"
+        exit 1
+    fi
     if [[ ! -f "$installed_dir/runpodctl" ]]; then
         echo "expected runpodctl to be installed"
         exit 1
@@ -118,6 +128,7 @@ run_download_cleanup_success_test() {
 
 run_download_cleanup_failure_test() {
     local work_dir="$TEST_TMPDIR/failure-cwd"
+    local expected_download_dir="$TEST_TMPDIR/failure-download"
     mkdir -p "$work_dir"
 
     set +e
@@ -127,6 +138,11 @@ run_download_cleanup_failure_test() {
         VERSION="v9.9.9"
         ARCHIVE_FILENAME="runpodctl-linux-amd64.tar.gz"
         DOWNLOAD_URL="https://example.test/$ARCHIVE_FILENAME"
+
+        mktemp() {
+            mkdir -p "$expected_download_dir"
+            printf '%s\n' "$expected_download_dir"
+        }
 
         wget() {
             local output=""
@@ -169,6 +185,10 @@ run_download_cleanup_failure_test() {
     fi
 
     assert_no_installer_artifacts "$work_dir"
+    if [[ -e "$expected_download_dir" ]]; then
+        echo "installer left download directory $expected_download_dir"
+        exit 1
+    fi
 }
 
 run_download_cleanup_success_test


### PR DESCRIPTION
## Summary

- Verifies self-update release archives against GoReleaser's versioned SHA-256 checksum asset before extraction or replacement.
- Applies the same fail-closed checksum verification to `install.sh` and removes temporary download artifacts after both successful and failed installations.
- Adds Go and shell coverage for checksum parsing, mismatch handling, verification ordering, and installer cleanup.

## Testing

- `go test ./... -count=1`
- `go build ./...`
- `bash -n install.sh`
- `bash -n install_test.sh`
- `bash install_test.sh`
- Built a disposable binary in a temporary directory and ran `update` against live GitHub release assets without replacing a production installation.
- Mutation-tested the installer cleanup regression coverage by removing the cleanup trap and confirming the test failed for the expected leftover directory.

## Security considerations

- Verification occurs before archive extraction and binary replacement.
- Missing checksum assets, missing archive entries, malformed digests, mismatches, and unavailable checksum tooling fail closed.
- This protects against accidental corruption or replacement of the archive alone. A compromise that replaces both the release archive and its checksum asset remains out of scope and would require signed release metadata.
