### PR TITLE
fix: STO-356: Use hash in model repo GraphQL queries

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -38,13 +38,12 @@ type ModelUser struct {
 
 // ModelVersion represents a specific version of a model stored in the repository.
 type ModelVersion struct {
-	UUID        string                 `json:"uuid,omitempty"`
-	Hash        string                 `json:"hash,omitempty"`
-	VersionHash string                 `json:"versionHash,omitempty"`
-	Status      string                 `json:"status,omitempty"`
-	CreatedAt   string                 `json:"createdAt,omitempty"`
-	UpdatedAt   string                 `json:"updatedAt,omitempty"`
-	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	UUID      string                 `json:"uuid,omitempty"`
+	Hash      string                 `json:"hash,omitempty"`
+	Status    string                 `json:"status,omitempty"`
+	CreatedAt string                 `json:"createdAt,omitempty"`
+	UpdatedAt string                 `json:"updatedAt,omitempty"`
+	Metadata  map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // ModelVersionStatus constants used when updating a model version's status.
@@ -358,7 +357,6 @@ func GetModels(input *GetModelsInput) ([]*Model, error) {
         versions {
                 uuid
                 hash
-                versionHash
                 status
                 metadata
                 createdAt
@@ -471,7 +469,6 @@ func GetModel(input *GetModelInput) (*Model, error) {
                                 versions {
                                         uuid
                                         hash
-                                        versionHash
                                         status
                                         metadata
                                         createdAt
@@ -917,7 +914,6 @@ func newUpdateModelVersionStatusInput(input *UpdateModelVersionStatusInput) (Inp
                                 modelVersion {
                                         uuid
                                         hash
-                                        versionHash
                                         status
                                         metadata
                                         createdAt

--- a/api/model_test.go
+++ b/api/model_test.go
@@ -86,9 +86,8 @@ func TestGetModelsRequestsVersionIdentifiers(t *testing.T) {
 						"provider": "LOCAL",
 						"versions": []map[string]interface{}{
 							{
-								"uuid":        "version-uuid",
-								"hash":        "version-hash",
-								"versionHash": "legacy-version-hash",
+								"uuid": "version-uuid",
+								"hash": "version-hash",
 							},
 						},
 					},
@@ -106,14 +105,17 @@ func TestGetModelsRequestsVersionIdentifiers(t *testing.T) {
 	if !strings.Contains(query, "uuid") {
 		t.Fatalf("expected GetModels query to request version uuid, got %s", query)
 	}
-	if !strings.Contains(query, "versionHash") {
-		t.Fatalf("expected GetModels query to request versionHash, got %s", query)
+	if !strings.Contains(query, "hash") {
+		t.Fatalf("expected GetModels query to request version hash, got %s", query)
+	}
+	if strings.Contains(query, "versionHash") {
+		t.Fatalf("GetModels query must not request versionHash, got %s", query)
 	}
 	if len(models) != 1 || len(models[0].Versions) != 1 {
 		t.Fatalf("expected one model version, got %#v", models)
 	}
 	version := models[0].Versions[0]
-	if version.UUID != "version-uuid" || version.Hash != "version-hash" || version.VersionHash != "legacy-version-hash" {
+	if version.UUID != "version-uuid" || version.Hash != "version-hash" {
 		t.Fatalf("expected version identifiers to decode, got %#v", version)
 	}
 }

--- a/cmd/model/addModelToRepo.go
+++ b/cmd/model/addModelToRepo.go
@@ -497,9 +497,6 @@ func uploadedModelVersionHash(model *api.Model, modelVersionUUID string) string 
 		if hash := strings.TrimSpace(version.Hash); hash != "" {
 			return hash
 		}
-		if hash := strings.TrimSpace(version.VersionHash); hash != "" {
-			return hash
-		}
 		return ""
 	}
 	return ""

--- a/cmd/model/removeModel.go
+++ b/cmd/model/removeModel.go
@@ -117,9 +117,6 @@ func removeModelVersion(owner, name, hash, version string) (*api.ModelRepoMutati
 	}
 	if hash != "" {
 		input.Hash = target.Hash
-		if input.Hash == "" {
-			input.Hash = target.VersionHash
-		}
 	} else {
 		input.UUID = target.UUID
 	}
@@ -146,7 +143,7 @@ func findModelVersion(model *api.Model, hash, version string) *api.ModelVersion 
 		if modelVersion == nil {
 			continue
 		}
-		if hash != "" && (modelVersion.Hash == hash || modelVersion.VersionHash == hash) {
+		if hash != "" && modelVersion.Hash == hash {
 			return modelVersion
 		}
 		if version != "" && modelVersion.UUID == version {

--- a/cmd/model/removeModel_test.go
+++ b/cmd/model/removeModel_test.go
@@ -11,7 +11,6 @@ func TestFindModelVersion(t *testing.T) {
 		Versions: []*api.ModelVersion{
 			nil,
 			{UUID: "version-uuid", Hash: "version-hash"},
-			{UUID: "other-uuid", VersionHash: "legacy-version-hash"},
 		},
 	}
 
@@ -22,7 +21,6 @@ func TestFindModelVersion(t *testing.T) {
 		want    string
 	}{
 		{name: "hash", hash: "version-hash", want: "version-uuid"},
-		{name: "version hash", hash: "legacy-version-hash", want: "other-uuid"},
 		{name: "uuid", version: "version-uuid", want: "version-uuid"},
 		{name: "missing", hash: "missing", want: ""},
 	}
@@ -53,24 +51,12 @@ func TestRemoveModelVersionUpdatesTargetVersion(t *testing.T) {
 		wantUUID string
 	}{
 		{
-			name: "hash uses canonical target hash",
+			name: "hash uses target hash",
 			model: &api.Model{
 				Owner: "owner",
 				Name:  "name",
 				Versions: []*api.ModelVersion{
-					{UUID: "version-uuid", Hash: "canonical-hash", VersionHash: "version-hash"},
-				},
-			},
-			hash:     "version-hash",
-			wantHash: "canonical-hash",
-		},
-		{
-			name: "hash falls back to target version hash",
-			model: &api.Model{
-				Owner: "owner",
-				Name:  "name",
-				Versions: []*api.ModelVersion{
-					{UUID: "version-uuid", VersionHash: "version-hash"},
+					{UUID: "version-uuid", Hash: "version-hash"},
 				},
 			},
 			hash:     "version-hash",


### PR DESCRIPTION
Remove the obsolete ModelVersion.versionHash selection and client field. Use hash as the sole model-version identifier for listing, lookup, status updates, and upload hash polling. Update unit tests for the current schema.

This resolves the issue with `--wait-for-hash` using an incorrect GQL query, causing a failure.