### PR TITLE
fix: STO-354: Preserve Hub deployment constraints on endpoint create

### DIFF
--- a/cmd/serverless/create.go
+++ b/cmd/serverless/create.go
@@ -23,6 +23,7 @@ var createCmd = &cobra.Command{
 
 requires either --template-id or --hub-id.
 --hub-id accepts both SERVERLESS and POD hub listings.
+hub deployment constraints are applied unless explicitly overridden by cli flags.
 
 examples:
   # create from a template
@@ -69,6 +70,16 @@ var (
 	createNetworkVolumeIDs string
 	createModelReferences  []string
 )
+
+type serverlessCreateClient interface {
+	GetListing(string) (*api.Listing, error)
+	ResolveServerlessGpuPoolID(string) (string, error)
+	CreateEndpointGQL(*api.EndpointCreateGQLInput) (*api.Endpoint, error)
+}
+
+var newServerlessCreateClient = func() (serverlessCreateClient, error) {
+	return api.NewClient()
+}
 
 func init() {
 	createCmd.Flags().StringVar(&createName, "name", "", "endpoint name")
@@ -120,24 +131,62 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	if strings.Contains(gpuTypeID, ",") {
 		return fmt.Errorf("only one gpu id is supported; use --gpu-count for multiple gpus of the same type")
 	}
-	if computeType == "CPU" && gpuTypeID != "" {
-		return fmt.Errorf("--gpu-id must be empty when --compute-type is CPU")
-	}
-	if computeType == "GPU" && strings.TrimSpace(createInstanceID) != "" {
-		return fmt.Errorf("--instance-id is only supported with --compute-type CPU")
-	}
-
-	if len(createModelReferences) > 0 && computeType != "GPU" {
-		return fmt.Errorf("--model-reference is only supported with --compute-type GPU")
+	if createHubID == "" || flagChanged(cmd, "compute-type") {
+		// Validate before the Hub lookup when its compute type cannot override it.
+		if err := validateComputeFlags(computeType, gpuTypeID, createInstanceID, createModelReferences); err != nil {
+			return err
+		}
 	}
 
 	if createNetworkVolumeID != "" && createNetworkVolumeIDs != "" {
 		return fmt.Errorf("--network-volume-id and --network-volume-ids are mutually exclusive")
 	}
 
-	client, err := api.NewClient()
+	client, err := newServerlessCreateClient()
 	if err != nil {
 		output.Error(err)
+		return err
+	}
+
+	var listing *api.Listing
+	var release *api.HubRelease
+	var hubConfig api.HubReleaseConfig
+	var imageName string
+	if createHubID != "" {
+		listing, err = client.GetListing(createHubID)
+		if err != nil {
+			output.Error(err)
+			return fmt.Errorf("failed to get hub listing: %w", err)
+		}
+		if listing.ListedRelease == nil {
+			return fmt.Errorf("hub listing %q has no published release", createHubID)
+		}
+
+		release = listing.ListedRelease
+		if release.Build != nil {
+			imageName = release.Build.ImageName
+		}
+		if imageName == "" {
+			return fmt.Errorf("hub listing %q has no built image; the release may still be building", createHubID)
+		}
+
+		if release.Config != "" {
+			if err := json.Unmarshal([]byte(release.Config), &hubConfig); err != nil {
+				return fmt.Errorf("failed to parse hub release config for %q: %w", createHubID, err)
+			}
+		}
+	}
+
+	if createHubID != "" && !flagChanged(cmd, "compute-type") && hubConfig.RunsOn != "" {
+		computeType = strings.ToUpper(strings.TrimSpace(hubConfig.RunsOn))
+	}
+	if computeType != "GPU" && computeType != "CPU" {
+		return fmt.Errorf("hub listing %q has unsupported runsOn value %q", createHubID, hubConfig.RunsOn)
+	}
+	if err := validateComputeFlags(computeType, gpuTypeID, createInstanceID, createModelReferences); err != nil {
+		if createHubID != "" && !flagChanged(cmd, "compute-type") && hubConfig.RunsOn != "" {
+			return fmt.Errorf("hub listing %q requires %s: %w", createHubID, computeType, err)
+		}
 		return err
 	}
 
@@ -160,11 +209,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		if createMinCudaVersion != "" {
 			fmt.Fprintln(cmd.ErrOrStderr(), "note: --min-cuda-version has no effect with --compute-type cpu; ignoring")
 		}
-		if cmd.Flags().Changed("gpu-count") {
+		if flagChanged(cmd, "gpu-count") {
 			fmt.Fprintln(cmd.ErrOrStderr(), "note: --gpu-count has no effect with --compute-type cpu; ignoring")
 		}
 	} else {
-		input.GpuCount = createGpuCount
+		input.GpuCount = hubGPUCount(hubConfig, createGpuCount, flagChanged(cmd, "gpu-count"))
 		if gpuTypeID != "" {
 			// saveEndpoint wants a gpu pool id, not a gpu type id; translate.
 			poolID, err := client.ResolveServerlessGpuPoolID(gpuTypeID)
@@ -176,6 +225,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		}
 		if createMinCudaVersion != "" {
 			input.MinCudaVersion = createMinCudaVersion
+		} else if createHubID != "" {
+			input.MinCudaVersion = hubMinCudaVersion(hubConfig.AllowedCudaVersions)
 		}
 	}
 
@@ -236,36 +287,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	endpointName := createName
 
-	// hub-id path: resolve listing, attach release + inline template (same as web ui).
+	// hub-id path: attach the resolved release and an inline template (same as web ui).
 	if createHubID != "" {
-		listing, err := client.GetListing(createHubID)
-		if err != nil {
-			output.Error(err)
-			return fmt.Errorf("failed to get hub listing: %w", err)
-		}
-		if listing.ListedRelease == nil {
-			return fmt.Errorf("hub listing %q has no published release", createHubID)
-		}
-
-		release := listing.ListedRelease
-
-		// build inline template from the hub release (same as web ui)
-		var imageName string
-		if release.Build != nil {
-			imageName = release.Build.ImageName
-		}
-		if imageName == "" {
-			return fmt.Errorf("hub listing %q has no built image; the release may still be building", createHubID)
-		}
-
 		containerDisk := 10
-		var hubConfig api.HubReleaseConfig
-		if release.Config != "" {
-			if err := json.Unmarshal([]byte(release.Config), &hubConfig); err == nil {
-				if hubConfig.ContainerDiskInGb > 0 {
-					containerDisk = hubConfig.ContainerDiskInGb
-				}
-			}
+		if hubConfig.ContainerDiskInGb > 0 {
+			containerDisk = hubConfig.ContainerDiskInGb
 		}
 
 		// translate hub release env config into pod env vars
@@ -349,6 +375,45 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	format := output.ParseFormat(cmd.Flag("output").Value.String())
 	return output.Print(endpoint, &output.Config{Format: format})
+}
+
+// flagChanged reports whether a command-line value was explicitly provided.
+// Hub release values must override CLI defaults, but never explicit user input.
+func flagChanged(cmd *cobra.Command, name string) bool {
+	flag := cmd.Flags().Lookup(name)
+	return flag != nil && flag.Changed
+}
+
+func hubGPUCount(config api.HubReleaseConfig, cliValue int, cliChanged bool) int {
+	if !cliChanged && config.GpuCount > 0 {
+		return config.GpuCount
+	}
+	return cliValue
+}
+
+// hubMinCudaVersion translates the ordered Hub constraint list to EndpointInput's
+// single minCudaVersion field. The first non-empty Hub value is sent; blank
+// optional values are ignored.
+func hubMinCudaVersion(versions []string) string {
+	for _, version := range versions {
+		if version = strings.TrimSpace(version); version != "" {
+			return version
+		}
+	}
+	return ""
+}
+
+func validateComputeFlags(computeType, gpuTypeID, instanceID string, modelReferences []string) error {
+	if computeType == "CPU" && gpuTypeID != "" {
+		return fmt.Errorf("--gpu-id must be empty when --compute-type is CPU")
+	}
+	if computeType == "GPU" && strings.TrimSpace(instanceID) != "" {
+		return fmt.Errorf("--instance-id is only supported with --compute-type CPU")
+	}
+	if len(modelReferences) > 0 && computeType != "GPU" {
+		return fmt.Errorf("--model-reference is only supported with --compute-type GPU")
+	}
+	return nil
 }
 
 // randomString builds a short lowercase suffix for generated endpoint/template

--- a/cmd/serverless/serverless_test.go
+++ b/cmd/serverless/serverless_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/runpod/runpodctl/internal/api"
 	"github.com/spf13/cobra"
 )
 
@@ -123,6 +124,49 @@ func snapshotCreateFlags(t *testing.T) {
 	createEnvVars, createModelReferences = nil, nil
 }
 
+type mockServerlessCreateClient struct {
+	listing       *api.Listing
+	getListingHit bool
+	createInput   *api.EndpointCreateGQLInput
+}
+
+func (c *mockServerlessCreateClient) GetListing(string) (*api.Listing, error) {
+	c.getListingHit = true
+	return c.listing, nil
+}
+
+func (c *mockServerlessCreateClient) ResolveServerlessGpuPoolID(gpuID string) (string, error) {
+	return gpuID, nil
+}
+
+func (c *mockServerlessCreateClient) CreateEndpointGQL(input *api.EndpointCreateGQLInput) (*api.Endpoint, error) {
+	c.createInput = input
+	return &api.Endpoint{ID: "endpoint-1", Name: input.Name}, nil
+}
+
+func mockCreateCommand(changedFlags ...string) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("compute-type", "GPU", "")
+	cmd.Flags().Int("gpu-count", 1, "")
+	cmd.Flags().String("output", "json", "")
+	for _, name := range changedFlags {
+		cmd.Flags().Lookup(name).Changed = true
+	}
+	return cmd
+}
+
+func mockHubListing(config string) *api.Listing {
+	return &api.Listing{
+		ID:    "hub-1",
+		Title: "Hub endpoint",
+		ListedRelease: &api.HubRelease{
+			ID:     "release-1",
+			Config: config,
+			Build:  &api.GitBuild{ImageName: "runpod/test:latest"},
+		},
+	}
+}
+
 // these validations all run before any api client/network call, so they're
 // safe to exercise without hitting the live api.
 func TestCreateCmd_Validations(t *testing.T) {
@@ -179,6 +223,99 @@ func TestCreateCmd_Validations(t *testing.T) {
 			if !strings.Contains(err.Error(), tc.wantErr) {
 				t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
 			}
+		})
+	}
+}
+
+func TestHubDeploymentConstraintPrecedence(t *testing.T) {
+	config := api.HubReleaseConfig{
+		GpuCount:            2,
+		AllowedCudaVersions: []string{"13.0", "12.8"},
+	}
+
+	if got := hubGPUCount(config, 1, false); got != 2 {
+		t.Fatalf("hub gpu count = %d, want 2", got)
+	}
+	if got := hubGPUCount(config, 4, true); got != 4 {
+		t.Fatalf("explicit gpu count = %d, want 4", got)
+	}
+	if got := hubMinCudaVersion(config.AllowedCudaVersions); got != "13.0" {
+		t.Fatalf("hub cuda version = %q, want 13.0", got)
+	}
+	if got := hubMinCudaVersion([]string{" ", "12.8"}); got != "12.8" {
+		t.Fatalf("blank cuda values were not ignored: %q", got)
+	}
+}
+
+func TestRunCreate_HubDeploymentConstraints(t *testing.T) {
+	cases := []struct {
+		name       string
+		config     string
+		setup      func()
+		wantInput  func(*testing.T, *api.EndpointCreateGQLInput)
+		wantErr    string
+		wantCreate bool
+	}{
+		{
+			name:   "applies gpu constraints",
+			config: `{"runsOn":"GPU","gpuCount":2,"allowedCudaVersions":["13.0","12.8"]}`,
+			wantInput: func(t *testing.T, input *api.EndpointCreateGQLInput) {
+				t.Helper()
+				if input.GpuCount != 2 || input.MinCudaVersion != "13.0" {
+					t.Fatalf("gpu constraints = count %d, cuda %q", input.GpuCount, input.MinCudaVersion)
+				}
+			},
+			wantCreate: true,
+		},
+		{
+			name:   "runsOn overrides default compute type",
+			config: `{"runsOn":"CPU"}`,
+			wantInput: func(t *testing.T, input *api.EndpointCreateGQLInput) {
+				t.Helper()
+				if len(input.InstanceIDs) != 1 || input.InstanceIDs[0] != defaultCPUInstanceID {
+					t.Fatalf("instance ids = %v, want default cpu instance", input.InstanceIDs)
+				}
+			},
+			wantCreate: true,
+		},
+		{
+			name:    "reports hub compute constraint",
+			config:  `{"runsOn":"CPU"}`,
+			setup:   func() { createGpuTypeID = "NVIDIA A40" },
+			wantErr: `hub listing "hub-1" requires CPU: --gpu-id must be empty`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshotCreateFlags(t)
+			createTemplateID, createHubID = "", "hub-1"
+			if tc.setup != nil {
+				tc.setup()
+			}
+
+			client := &mockServerlessCreateClient{listing: mockHubListing(tc.config)}
+			oldFactory := newServerlessCreateClient
+			newServerlessCreateClient = func() (serverlessCreateClient, error) { return client, nil }
+			t.Cleanup(func() { newServerlessCreateClient = oldFactory })
+
+			err := runCreate(mockCreateCommand(), nil)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
+				}
+				if !client.getListingHit {
+					t.Fatal("hub lookup was skipped before Hub-derived validation")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantCreate && client.createInput == nil {
+				t.Fatal("endpoint create was not called")
+			}
+			tc.wantInput(t, client.createInput)
 		})
 	}
 }

--- a/docs/runpodctl_serverless_create.md
+++ b/docs/runpodctl_serverless_create.md
@@ -8,6 +8,7 @@ create a new serverless endpoint.
 
 requires either --template-id or --hub-id.
 --hub-id accepts both SERVERLESS and POD hub listings.
+hub deployment constraints are applied unless explicitly overridden by cli flags.
 
 examples:
   # create from a template

--- a/internal/api/hub.go
+++ b/internal/api/hub.go
@@ -55,10 +55,12 @@ type GitBuild struct {
 
 // HubReleaseConfig is the parsed config from a hub release
 type HubReleaseConfig struct {
-	ContainerDiskInGb int                   `json:"containerDiskInGb,omitempty"`
-	GpuIDs            string                `json:"gpuIds,omitempty"`
-	GpuCount          int                   `json:"gpuCount,omitempty"`
-	Env               []HubReleaseConfigEnv `json:"env,omitempty"`
+	ContainerDiskInGb   int                   `json:"containerDiskInGb,omitempty"`
+	GpuIDs              string                `json:"gpuIds,omitempty"`
+	GpuCount            int                   `json:"gpuCount,omitempty"`
+	RunsOn              string                `json:"runsOn,omitempty"`
+	AllowedCudaVersions []string              `json:"allowedCudaVersions,omitempty"`
+	Env                 []HubReleaseConfigEnv `json:"env,omitempty"`
 }
 
 // HubReleaseConfigEnv is an env var entry in the hub release config

--- a/internal/api/hub_test.go
+++ b/internal/api/hub_test.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestHubReleaseConfigDeploymentConstraints(t *testing.T) {
+	var config HubReleaseConfig
+	err := json.Unmarshal([]byte(`{
+		"runsOn":"GPU",
+		"containerDiskInGb":150,
+		"gpuIds":"ADA_80_PRO,AMPERE_80",
+		"gpuCount":2,
+		"allowedCudaVersions":["13.0","12.8"]
+	}`), &config)
+	if err != nil {
+		t.Fatalf("unmarshal hub config: %v", err)
+	}
+
+	if config.RunsOn != "GPU" || config.ContainerDiskInGb != 150 || config.GpuIDs != "ADA_80_PRO,AMPERE_80" || config.GpuCount != 2 {
+		t.Fatalf("unexpected deployment constraints: %#v", config)
+	}
+	if want := []string{"13.0", "12.8"}; !reflect.DeepEqual(config.AllowedCudaVersions, want) {
+		t.Fatalf("allowed cuda versions = %#v, want %#v", config.AllowedCudaVersions, want)
+	}
+}


### PR DESCRIPTION
# Preserve Hub deployment constraints on endpoint create

Apply Hub `runsOn`, GPU count, and CUDA requirements when creating serverless endpoints from a Hub release, while preserving explicit CLI overrides. Fail clearly on invalid release config and add focused coverage for config parsing and precedence.
