### PR TITLE
ci: add automated Linear release tracking (SLS-172)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,3 +44,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  # Linear release tracking (SLS-172). Only runs for tag pushes, not manual dispatch.
+  linear-sync:
+    name: Linear Release Sync
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: sync
+          version: ${{ github.ref_name }}
+          name: runpodctl ${{ github.ref_name }}
+
+  linear-complete:
+    name: Linear Release Complete
+    needs: [release, linear-sync]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_RELEASE_ACCESS_KEY }}
+          command: complete
+          version: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ steps.app-token.outputs.token }}
 
-  # Linear release tracking (SLS-172). Only runs for tag pushes, not manual dispatch.
+  # Linear release tracking. Only runs for tag pushes, not manual dispatch.
   linear-sync:
     name: Linear Release Sync
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
     needs: release
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,6 +70,8 @@ jobs:
     needs: [release, linear-sync]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Tag-based repo (GoReleaser). Adds `linear-sync` + `linear-complete` jobs to `.github/workflows/release.yml`, gated to tag pushes (`refs/tags/*`) so manual `workflow_dispatch` runs don't sync. Version = the pushed tag (`github.ref_name`).
## Requirements
- Repo/org secret **`LINEAR_RELEASE_ACCESS_KEY`** must be set (same secret already used by `main-ui`).

Implements SLS-172 (part of SLS-160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)