### PR TITLE
fix: change int params in the EndpointupdateRequest struct

### DIFF
--- a/cmd/serverless/create.go
+++ b/cmd/serverless/create.go
@@ -246,8 +246,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	input := &api.EndpointCreateGQLInput{
-		WorkersMin: createWorkersMin,
-		WorkersMax: createWorkersMax,
+		WorkersMin: &createWorkersMin,
+		WorkersMax: &createWorkersMax,
 	}
 
 	// compute type: gpu uses a gpu pool id, cpu uses an instance id.
@@ -308,7 +308,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if createExecutionTimeout >= 0 {
 		// 0 is allowed (server treats it as "no per-request limit").
-		input.ExecutionTimeoutMs = createExecutionTimeout * 1000
+		ms := createExecutionTimeout * 1000
+		input.ExecutionTimeoutMs = &ms
 	}
 
 	// flash boot maps to the flashBootType enum (off|flashboot); always set so

--- a/cmd/serverless/serverless_test.go
+++ b/cmd/serverless/serverless_test.go
@@ -3,7 +3,9 @@ package serverless
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -314,6 +316,70 @@ func TestHubDeploymentConstraintPrecedence(t *testing.T) {
 	}
 	if got := hubMinCudaVersion([]string{" ", "12.8"}); got != "12.8" {
 		t.Fatalf("blank cuda values were not ignored: %q", got)
+	}
+}
+
+func TestRunCreate_ZeroValuedNumericFlagsAreSent(t *testing.T) {
+	cases := []struct {
+		name                                string
+		workersMin, workersMax, execTimeout int
+		wantMin, wantMax, wantExecTimeoutMs int
+	}{
+		// distinct values: identical ones would hide a flag wired to the wrong field.
+		{"distinct values", 0, 2, 7, 0, 2, 7000},
+		{"all zero", 0, 0, 0, 0, 0, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshotCreateFlags(t)
+			createTemplateID, createHubID = "tpl-1", ""
+			createComputeType = "CPU"
+			createInstanceID = defaultCPUInstanceID
+			createWorkersMin = tc.workersMin
+			createWorkersMax = tc.workersMax
+			createExecutionTimeout = tc.execTimeout
+			createIdleTimeout = -1
+			createScaleThreshold = -1
+
+			client := &mockServerlessCreateClient{}
+			oldFactory := newServerlessCreateClient
+			newServerlessCreateClient = func() (serverlessCreateClient, error) { return client, nil }
+			t.Cleanup(func() { newServerlessCreateClient = oldFactory })
+			installMockWaitHealthClient(t, client)
+
+			if err := runCreate(mockCreateCommand(), nil); err != nil {
+				t.Fatal(err)
+			}
+			if client.createInput == nil {
+				t.Fatal("endpoint create was not called")
+			}
+
+			in := client.createInput
+			if in.WorkersMin == nil || *in.WorkersMin != tc.wantMin {
+				t.Errorf("workersMin = %v, want %d", in.WorkersMin, tc.wantMin)
+			}
+			if in.WorkersMax == nil || *in.WorkersMax != tc.wantMax {
+				t.Errorf("workersMax = %v, want %d", in.WorkersMax, tc.wantMax)
+			}
+			if in.ExecutionTimeoutMs == nil || *in.ExecutionTimeoutMs != tc.wantExecTimeoutMs {
+				t.Errorf("executionTimeoutMs = %v, want %d", in.ExecutionTimeoutMs, tc.wantExecTimeoutMs)
+			}
+
+			data, err := json.Marshal(in)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			for _, want := range []string{
+				fmt.Sprintf(`"workersMin":%d`, tc.wantMin),
+				fmt.Sprintf(`"workersMax":%d`, tc.wantMax),
+				fmt.Sprintf(`"executionTimeoutMs":%d`, tc.wantExecTimeoutMs),
+			} {
+				if !strings.Contains(string(data), want) {
+					t.Errorf("expected %s in create input, got %s", want, data)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/serverless/update.go
+++ b/cmd/serverless/update.go
@@ -49,7 +49,7 @@ func init() {
 	updateCmd.Flags().StringVar(&updateTemplateID, "template-id", "", "new template id")
 	updateCmd.Flags().IntVar(&updateWorkersMin, "workers-min", -1, "new minimum number of workers")
 	updateCmd.Flags().IntVar(&updateWorkersMax, "workers-max", -1, "new maximum number of workers")
-	updateCmd.Flags().IntVar(&updateIdleTimeout, "idle-timeout", -1, "new idle timeout in seconds")
+	updateCmd.Flags().IntVar(&updateIdleTimeout, "idle-timeout", -1, "new idle timeout in seconds (1-3600)")
 	updateCmd.Flags().StringVar(&updateScaleBy, "scale-by", "", "autoscale strategy: delay (seconds of queue wait) or requests (pending request count)")
 	updateCmd.Flags().IntVar(&updateScaleThreshold, "scale-threshold", -1, "trigger point for autoscaler (delay: seconds, requests: count)")
 	updateCmd.Flags().StringArrayVar(&updateModelRefs, "model-reference", nil, "model reference to cache on the endpoint (repeatable); replaces existing model references")
@@ -61,6 +61,13 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	if updateClearModels && len(updateModelRefs) > 0 {
 		return fmt.Errorf("--clear-models and --model-reference are mutually exclusive")
+	}
+	if updateIdleTimeout >= 0 && (updateIdleTimeout < 1 || updateIdleTimeout > 3600) {
+		return fmt.Errorf("--idle-timeout must be between 1 and 3600 seconds")
+	}
+	if updateScaleThreshold >= 0 && updateScaleThreshold < 1 {
+		// the api floor is 0.5, but this flag is an int, so 1 is the lowest it can express.
+		return fmt.Errorf("--scale-threshold must be at least 1")
 	}
 
 	client, err := api.NewClient()

--- a/cmd/serverless/update.go
+++ b/cmd/serverless/update.go
@@ -76,15 +76,15 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		hasRESTUpdate = true
 	}
 	if updateWorkersMin >= 0 {
-		req.WorkersMin = updateWorkersMin
+		req.WorkersMin = &updateWorkersMin
 		hasRESTUpdate = true
 	}
 	if updateWorkersMax >= 0 {
-		req.WorkersMax = updateWorkersMax
+		req.WorkersMax = &updateWorkersMax
 		hasRESTUpdate = true
 	}
 	if updateIdleTimeout >= 0 {
-		req.IdleTimeout = updateIdleTimeout
+		req.IdleTimeout = &updateIdleTimeout
 		hasRESTUpdate = true
 	}
 	if updateScaleBy != "" {
@@ -99,7 +99,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		hasRESTUpdate = true
 	}
 	if updateScaleThreshold >= 0 {
-		req.ScalerValue = updateScaleThreshold
+		req.ScalerValue = &updateScaleThreshold
 		hasRESTUpdate = true
 	}
 

--- a/cmd/serverless/update_test.go
+++ b/cmd/serverless/update_test.go
@@ -170,6 +170,238 @@ func TestRunUpdate_ClearModelsAndModelReferenceMutuallyExclusive(t *testing.T) {
 	}
 }
 
+// distinct values: identical ones would hide a flag wired to the wrong field.
+func TestRunUpdate_AllNumericFlagsAreWired(t *testing.T) {
+	resetUpdateVars(t)
+
+	var patchBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/endpoints/ep-123":
+			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
+				t.Errorf("decode rest request: %v", err)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "ep-123"})
+		case r.Method == http.MethodGet && r.URL.Path == "/endpoints/ep-123":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "ep-123"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+	viper.Set("restApiUrl", server.URL)
+	viper.Set("apiUrl", server.URL)
+	t.Cleanup(func() {
+		viper.Set("restApiUrl", "")
+		viper.Set("apiUrl", "")
+	})
+
+	updateName = "renamed"
+	updateTemplateID = ""
+	updateWorkersMin = 0
+	updateWorkersMax = 7
+	updateIdleTimeout = 30
+	updateScaleBy = "requests"
+	updateScaleThreshold = 4
+	updateModelRefs = nil
+	updateClearModels = false
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("output", "json", "")
+
+	if err := runUpdate(cmd, []string{"ep-123"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]interface{}{
+		"name":        "renamed",
+		"workersMin":  float64(0),
+		"workersMax":  float64(7),
+		"idleTimeout": float64(30),
+		"scalerValue": float64(4),
+		"scalerType":  "REQUEST_COUNT",
+	}
+	for field, expected := range want {
+		got, ok := patchBody[field]
+		if !ok {
+			t.Errorf("expected %s in patch body, got %#v", field, patchBody)
+			continue
+		}
+		if got != expected {
+			t.Errorf("expected %s %#v, got %#v", field, expected, got)
+		}
+	}
+}
+
+func TestRunUpdate_WorkersMinZeroIsSent(t *testing.T) {
+	resetUpdateVars(t)
+
+	var patchBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/endpoints/ep-123":
+			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
+				t.Fatalf("decode rest request: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":         "ep-123",
+				"workersMin": 0,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/endpoints/ep-123":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":         "ep-123",
+				"workersMin": 0,
+			})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+	viper.Set("restApiUrl", server.URL)
+	viper.Set("apiUrl", server.URL)
+	t.Cleanup(func() {
+		viper.Set("restApiUrl", "")
+		viper.Set("apiUrl", "")
+	})
+
+	updateName = ""
+	updateTemplateID = ""
+	updateWorkersMin = 0
+	updateWorkersMax = -1
+	updateIdleTimeout = -1
+	updateScaleBy = ""
+	updateScaleThreshold = -1
+	updateModelRefs = nil
+	updateClearModels = false
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("output", "json", "")
+
+	if err := runUpdate(cmd, []string{"ep-123"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// see issue #298.
+	if got, ok := patchBody["workersMin"]; !ok {
+		t.Fatalf("expected workersMin in patch body, got %#v", patchBody)
+	} else if got != float64(0) {
+		t.Fatalf("expected workersMin 0, got %#v", got)
+	}
+}
+
+func TestRunUpdate_RejectsOutOfRangeNumericFlags(t *testing.T) {
+	cases := []struct {
+		name           string
+		idleTimeout    int
+		scaleThreshold int
+		wantErr        string
+	}{
+		{"idle timeout zero", 0, -1, "--idle-timeout must be between 1 and 3600 seconds"},
+		{"idle timeout too large", 3601, -1, "--idle-timeout must be between 1 and 3600 seconds"},
+		{"scale threshold zero", -1, 0, "--scale-threshold must be at least 1"},
+	}
+
+	// boundary values: an off-by-one in the guard would slip past otherwise.
+	accepted := []struct {
+		name           string
+		idleTimeout    int
+		scaleThreshold int
+		wantField      string
+		wantValue      float64
+	}{
+		{"idle timeout min", 1, -1, "idleTimeout", 1},
+		{"idle timeout max", 3600, -1, "idleTimeout", 3600},
+		{"scale threshold min", -1, 1, "scalerValue", 1},
+	}
+
+	for _, tc := range accepted {
+		t.Run("accepts "+tc.name, func(t *testing.T) {
+			resetUpdateVars(t)
+
+			var patchBody map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPatch && r.URL.Path == "/endpoints/ep-123":
+					if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
+						t.Errorf("decode rest request: %v", err)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "ep-123"})
+				case r.Method == http.MethodGet && r.URL.Path == "/endpoints/ep-123":
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "ep-123"})
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			t.Setenv("RUNPOD_API_KEY", "test-key")
+			viper.Set("restApiUrl", server.URL)
+			viper.Set("apiUrl", server.URL)
+			t.Cleanup(func() {
+				viper.Set("restApiUrl", "")
+				viper.Set("apiUrl", "")
+			})
+
+			updateName = ""
+			updateTemplateID = ""
+			updateWorkersMin = -1
+			updateWorkersMax = -1
+			updateIdleTimeout = tc.idleTimeout
+			updateScaleBy = ""
+			updateScaleThreshold = tc.scaleThreshold
+			updateModelRefs = nil
+			updateClearModels = false
+
+			cmd := &cobra.Command{}
+			cmd.Flags().String("output", "json", "")
+
+			if err := runUpdate(cmd, []string{"ep-123"}); err != nil {
+				t.Fatalf("expected boundary value to be accepted, got %v", err)
+			}
+			if got := patchBody[tc.wantField]; got != tc.wantValue {
+				t.Errorf("expected %s %v, got %#v", tc.wantField, tc.wantValue, got)
+			}
+		})
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetUpdateVars(t)
+
+			updateName = ""
+			updateTemplateID = ""
+			updateWorkersMin = -1
+			updateWorkersMax = -1
+			updateIdleTimeout = tc.idleTimeout
+			updateScaleBy = ""
+			updateScaleThreshold = tc.scaleThreshold
+			updateModelRefs = nil
+			updateClearModels = false
+
+			cmd := &cobra.Command{}
+			cmd.Flags().String("output", "json", "")
+
+			// validation must fail before any api client is built, so no server here.
+			err := runUpdate(cmd, []string{"ep-123"})
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestRunUpdate_ModelReferences(t *testing.T) {
 	resetUpdateVars(t)
 

--- a/docs/runpodctl_serverless_update.md
+++ b/docs/runpodctl_serverless_update.md
@@ -28,7 +28,7 @@ runpodctl serverless update <endpoint-id> [flags]
 ```
       --clear-models                  remove all model references from the endpoint
   -h, --help                          help for update
-      --idle-timeout int              new idle timeout in seconds (default -1)
+      --idle-timeout int              new idle timeout in seconds (1-3600) (default -1)
       --model-reference stringArray   model reference to cache on the endpoint (repeatable); replaces existing model references
       --name string                   new endpoint name
       --scale-by string               autoscale strategy: delay (seconds of queue wait) or requests (pending request count)

--- a/e2e/serverless_invoke_test.go
+++ b/e2e/serverless_invoke_test.go
@@ -262,12 +262,13 @@ func TestE2E_ServerlessInvokeLifecycle(t *testing.T) {
 		t.Logf("deleted template %s", template.ID)
 	})
 
+	workersMin, workersMax := 0, 1
 	endpoint, err := client.CreateEndpointGQL(&api.EndpointCreateGQLInput{
 		Name:        "e2e-invoke-" + suffix,
 		TemplateID:  template.ID,
 		InstanceIDs: []string{"cpu3g-4-16"},
-		WorkersMin:  0,
-		WorkersMax:  1,
+		WorkersMin:  &workersMin,
+		WorkersMax:  &workersMax,
 	})
 	if err != nil {
 		t.Fatalf("failed to create endpoint: %v", err)

--- a/internal/api/endpoints.go
+++ b/internal/api/endpoints.go
@@ -9,7 +9,9 @@ import (
 	"github.com/runpod/runpodctl/internal/configenv"
 )
 
-// Endpoint represents a serverless endpoint
+// Endpoint represents a serverless endpoint. Its numeric fields carry no
+// omitempty: this struct is re-marshalled to render cli output, and 0 is a real
+// value for all of them.
 type Endpoint struct {
 	ID                 string                  `json:"id"`
 	Name               string                  `json:"name"`
@@ -19,17 +21,17 @@ type Endpoint struct {
 	NetworkVolumeID    string                  `json:"networkVolumeId,omitempty"`
 	NetworkVolumeIDs   []EndpointNetworkVolume `json:"networkVolumeIds,omitempty"`
 	Locations          string                  `json:"locations,omitempty"`
-	IdleTimeout        int                     `json:"idleTimeout,omitempty"`
+	IdleTimeout        int                     `json:"idleTimeout"`
 	ScalerType         string                  `json:"scalerType,omitempty"`
-	ScalerValue        int                     `json:"scalerValue,omitempty"`
-	WorkersMin         int                     `json:"workersMin,omitempty"`
-	WorkersMax         int                     `json:"workersMax,omitempty"`
-	GpuCount           int                     `json:"gpuCount,omitempty"`
+	ScalerValue        int                     `json:"scalerValue"`
+	WorkersMin         int                     `json:"workersMin"`
+	WorkersMax         int                     `json:"workersMax"`
+	GpuCount           int                     `json:"gpuCount"`
 	MinCudaVersion     string                  `json:"minCudaVersion,omitempty"`
 	Flashboot          *bool                   `json:"flashboot,omitempty"`
 	FlashBootType      string                  `json:"flashBootType,omitempty"`
 	ComputeType        string                  `json:"computeType,omitempty"`
-	ExecutionTimeoutMs int                     `json:"executionTimeoutMs,omitempty"`
+	ExecutionTimeoutMs int                     `json:"executionTimeoutMs"`
 	ModelReferences    []string                `json:"modelReferences,omitempty"`
 	Template           map[string]interface{}  `json:"template,omitempty"`
 	Workers            []interface{}           `json:"workers,omitempty"`
@@ -360,22 +362,23 @@ type NetworkVolumeIDInput struct {
 // saveEndpoint mutation. all serverless creates go through this path, so every
 // cli flag maps to a field here (the web console uses the same mutation).
 type EndpointCreateGQLInput struct {
-	Name               string                 `json:"name"`
-	HubReleaseID       string                 `json:"hubReleaseId,omitempty"`
-	TemplateID         string                 `json:"templateId,omitempty"`
-	Template           *EndpointTemplateInput `json:"template,omitempty"`
-	GpuIDs             string                 `json:"gpuIds,omitempty"`
+	Name         string                 `json:"name"`
+	HubReleaseID string                 `json:"hubReleaseId,omitempty"`
+	TemplateID   string                 `json:"templateId,omitempty"`
+	Template     *EndpointTemplateInput `json:"template,omitempty"`
+	GpuIDs       string                 `json:"gpuIds,omitempty"`
+	// plain int: the api minimum is 1, so 0 is never worth sending.
 	GpuCount           int                    `json:"gpuCount,omitempty"`
 	InstanceIDs        []string               `json:"instanceIds,omitempty"`
-	WorkersMin         int                    `json:"workersMin,omitempty"`
-	WorkersMax         int                    `json:"workersMax,omitempty"`
+	WorkersMin         *int                   `json:"workersMin,omitempty"`
+	WorkersMax         *int                   `json:"workersMax,omitempty"`
 	Locations          string                 `json:"locations,omitempty"`
 	NetworkVolumeID    string                 `json:"networkVolumeId,omitempty"`
 	NetworkVolumeIDs   []NetworkVolumeIDInput `json:"networkVolumeIds,omitempty"`
 	IdleTimeout        int                    `json:"idleTimeout,omitempty"`
 	ScalerType         string                 `json:"scalerType,omitempty"`
 	ScalerValue        int                    `json:"scalerValue,omitempty"`
-	ExecutionTimeoutMs int                    `json:"executionTimeoutMs,omitempty"`
+	ExecutionTimeoutMs *int                   `json:"executionTimeoutMs,omitempty"`
 	MinCudaVersion     string                 `json:"minCudaVersion,omitempty"`
 	FlashBootType      string                 `json:"flashBootType,omitempty"`
 	ModelReferences    []string               `json:"modelReferences,omitempty"`

--- a/internal/api/endpoints.go
+++ b/internal/api/endpoints.go
@@ -117,11 +117,11 @@ type EndpointListResponse struct {
 // EndpointUpdateRequest is the request to update an endpoint
 type EndpointUpdateRequest struct {
 	Name        string `json:"name,omitempty"`
-	WorkersMin  int    `json:"workersMin,omitempty"`
-	WorkersMax  int    `json:"workersMax,omitempty"`
-	IdleTimeout int    `json:"idleTimeout,omitempty"`
+	WorkersMin  *int   `json:"workersMin,omitempty"`
+	WorkersMax  *int   `json:"workersMax,omitempty"`
+	IdleTimeout *int   `json:"idleTimeout,omitempty"`
 	ScalerType  string `json:"scalerType,omitempty"`
-	ScalerValue int    `json:"scalerValue,omitempty"`
+	ScalerValue *int   `json:"scalerValue,omitempty"`
 	Flashboot   *bool  `json:"flashboot,omitempty"`
 }
 

--- a/internal/api/endpoints_test.go
+++ b/internal/api/endpoints_test.go
@@ -195,6 +195,9 @@ func TestCreateEndpointGQLIncludesModelReferences(t *testing.T) {
 }
 
 func TestUpdateEndpoint(t *testing.T) {
+	wrkMin := 0
+	wrkMax := 5
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("expected PATCH, got %s", r.Method)
@@ -204,7 +207,8 @@ func TestUpdateEndpoint(t *testing.T) {
 		}
 		json.NewEncoder(w).Encode(Endpoint{
 			ID:         "ep-123",
-			WorkersMax: 5,
+			WorkersMin: wrkMin,
+			WorkersMax: wrkMax,
 		})
 	}))
 	defer server.Close()
@@ -213,9 +217,9 @@ func TestUpdateEndpoint(t *testing.T) {
 
 	client, _ := NewClient()
 	client.baseURL = server.URL
-	wrkMax := 5
 
 	endpoint, err := client.UpdateEndpoint("ep-123", &EndpointUpdateRequest{
+		WorkersMin: &wrkMin,
 		WorkersMax: &wrkMax,
 	})
 	if err != nil {

--- a/internal/api/endpoints_test.go
+++ b/internal/api/endpoints_test.go
@@ -213,9 +213,10 @@ func TestUpdateEndpoint(t *testing.T) {
 
 	client, _ := NewClient()
 	client.baseURL = server.URL
+	wrkMax := 5
 
 	endpoint, err := client.UpdateEndpoint("ep-123", &EndpointUpdateRequest{
-		WorkersMax: 5,
+		WorkersMax: &wrkMax,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/api/endpoints_test.go
+++ b/internal/api/endpoints_test.go
@@ -99,6 +99,45 @@ func TestGetEndpoint(t *testing.T) {
 	}
 }
 
+func TestEndpointCreateGQLInputZeroValues(t *testing.T) {
+	zero := 0
+	data, err := json.Marshal(EndpointCreateGQLInput{
+		Name:               "ep",
+		WorkersMin:         &zero,
+		WorkersMax:         &zero,
+		ExecutionTimeoutMs: &zero,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, field := range []string{"workersMin", "workersMax", "executionTimeoutMs"} {
+		got, ok := out[field]
+		if !ok {
+			t.Errorf("expected %s in create input, got %s", field, data)
+			continue
+		}
+		if got != float64(0) {
+			t.Errorf("expected %s 0, got %#v", field, got)
+		}
+	}
+
+	// unset must stay omitted, or create would clobber server defaults.
+	bare, err := json.Marshal(EndpointCreateGQLInput{Name: "ep"})
+	if err != nil {
+		t.Fatalf("marshal bare: %v", err)
+	}
+	for _, field := range []string{"workersMin", "workersMax", "executionTimeoutMs", "gpuCount"} {
+		if strings.Contains(string(bare), field) {
+			t.Errorf("expected %s to be omitted when unset, got %s", field, bare)
+		}
+	}
+}
+
 func TestEndpointCreateGQLInputSerialization(t *testing.T) {
 	data, err := json.Marshal(EndpointCreateGQLInput{
 		Name:             "ep",
@@ -194,9 +233,55 @@ func TestCreateEndpointGQLIncludesModelReferences(t *testing.T) {
 	}
 }
 
+func TestEndpointZeroNumericFieldsSurviveOutput(t *testing.T) {
+	render := func(t *testing.T, body string) map[string]interface{} {
+		t.Helper()
+		var e Endpoint
+		if err := json.Unmarshal([]byte(body), &e); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		data, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(data, &out); err != nil {
+			t.Fatalf("unmarshal output: %v", err)
+		}
+		return out
+	}
+
+	// all zero on purpose: a presence check only detects omitempty at 0.
+	allZero := render(t, `{"id":"ep-123","name":"my-endpoint","workersMin":0,"workersMax":0,
+		"idleTimeout":0,"scalerValue":0,"gpuCount":0,"executionTimeoutMs":0}`)
+	for _, field := range []string{"workersMin", "workersMax", "idleTimeout", "scalerValue", "gpuCount", "executionTimeoutMs"} {
+		got, ok := allZero[field]
+		if !ok {
+			t.Errorf("expected %s in rendered output, got %#v", field, allZero)
+			continue
+		}
+		if got != float64(0) {
+			t.Errorf("expected %s 0, got %#v", field, got)
+		}
+	}
+
+	nonZero := render(t, `{"id":"ep-123","name":"my-endpoint","workersMin":2,"workersMax":3,"idleTimeout":5}`)
+	if nonZero["workersMin"] != float64(2) {
+		t.Errorf("expected workersMin 2, got %#v", nonZero["workersMin"])
+	}
+	if nonZero["workersMax"] != float64(3) {
+		t.Errorf("expected workersMax 3, got %#v", nonZero["workersMax"])
+	}
+	if nonZero["idleTimeout"] != float64(5) {
+		t.Errorf("expected idleTimeout 5, got %#v", nonZero["idleTimeout"])
+	}
+}
+
 func TestUpdateEndpoint(t *testing.T) {
 	wrkMin := 0
 	wrkMax := 5
+
+	var body map[string]interface{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
@@ -205,11 +290,11 @@ func TestUpdateEndpoint(t *testing.T) {
 		if r.URL.Path != "/endpoints/ep-123" {
 			t.Errorf("expected /endpoints/ep-123, got %s", r.URL.Path)
 		}
-		json.NewEncoder(w).Encode(Endpoint{
-			ID:         "ep-123",
-			WorkersMin: wrkMin,
-			WorkersMax: wrkMax,
-		})
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		// raw wire shape so this does not depend on Endpoint's tags.
+		w.Write([]byte(`{"id":"ep-123","workersMin":0,"workersMax":5}`))
 	}))
 	defer server.Close()
 
@@ -224,6 +309,26 @@ func TestUpdateEndpoint(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, ok := body["workersMin"]; !ok {
+		t.Errorf("expected workersMin in patch body, got %#v", body)
+	} else if got != float64(0) {
+		t.Errorf("expected workersMin 0, got %#v", got)
+	}
+	if got := body["workersMax"]; got != float64(5) {
+		t.Errorf("expected workersMax 5, got %#v", got)
+	}
+	// unset fields must still be omitted rather than sent as zeroes.
+	if _, ok := body["idleTimeout"]; ok {
+		t.Errorf("expected idleTimeout to be omitted, got %#v", body)
+	}
+	if _, ok := body["scalerValue"]; ok {
+		t.Errorf("expected scalerValue to be omitted, got %#v", body)
+	}
+
+	if endpoint.ID != "ep-123" {
+		t.Errorf("expected ep-123, got %q", endpoint.ID)
 	}
 	if endpoint.WorkersMax != 5 {
 		t.Errorf("expected 5, got %d", endpoint.WorkersMax)


### PR DESCRIPTION
# Summary

Updated the following parameters in the api.EndpointUpdateRequest struct from type `int` to an integer pointer (`*int`).

* WorkersMin
* WorkersMax
* IdleTimeout
* ScalerValue

This is to fix a bug in the enpoints where a value of `0` causes the generated JSON to omit these fields as "empty" as per the `omitempty` JSON tag. Changing them to integer pointer (`*int`) will allow a `nil` value to trigger the `omitempty` JSON tag, while a value of `0` will be treated as a valid value.

fixes #298

Test plan:
- [x] go test ./...
- [ ] go test -tags e2e ./e2e