### PR TITLE
docs: correct output-format, exec exit code, and skill path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,4 +24,4 @@ This document exists for non-obvious, error-prone shortcomings in the codebase, 
 - default output format is json (for agent consumption); never change this default.
 - e2e tests cost real money — always clean up resources with `t.Cleanup`.
 - always e2e test cli changes before considering work done: build the binary, run the new/changed commands against the live api (`RUNPOD_API_KEY` is in the env), and clean up any created resources immediately after verifying the response. this is non-negotiable.
-- keep the runpodctl skill in sync: https://github.com/runpod/skills/tree/main/runpodctl — update it whenever commands, flags, or behavior change.
+- keep the runpodctl skill in sync: https://github.com/runpod/runpod-plugins-official/tree/main/plugins/runpod/skills/runpodctl — update it whenever commands, flags, or behavior change.

--- a/README.md
+++ b/README.md
@@ -131,13 +131,17 @@ runpodctl receive 8338-galileo-collect-fidel
 
 ## output format
 
-default output is json (optimized for agents). use `--output` flag for alternatives:
+default output is json (optimized for agents). `--output` takes `json` or `yaml`:
 
 ```bash
 runpodctl pod list                    # json (default)
-runpodctl pod list --output=table     # human-readable table
 runpodctl pod list --output=yaml      # yaml format
 ```
+
+there is no table format. the value is matched case-sensitively and an
+unrecognized one is not an error — it falls back to json silently, so
+`--output=table` and `--output=YAML` both return json. (the legacy `get pod` and
+`get cloud` commands print a table unconditionally and ignore `--output`.)
 
 ### error format
 
@@ -181,11 +185,11 @@ carry no `code`:
 | surface | shape |
 | --- | --- |
 | legacy `get/create/remove/start/stop pod`, `create/remove pods`, `get cloud` | `Error: <msg>` via cobra, exit 1 |
-| `exec` | plaintext, exit 1 |
+| `exec` | progress on **stdout**, error plaintext on stderr, and exits **0** — it uses `Run`, not `RunE`, so the error never reaches the sink. also polls up to 5 minutes (`maxPollTime`) for the pod's ssh info before giving up |
 | `project` | prints to **stdout** and exits 0 (bug, tracked as CON-816) |
 
 so a parser should tolerate a non-json line on stderr from those, and must not
-rely on the exit code for `project` until CON-816 lands.
+rely on the exit code for `exec` or `project` until CON-816 lands.
 
 ## environment variables
 


### PR DESCRIPTION
## what

Three README/AGENTS.md claims that don't match the code. Docs only — no code change.

| claim | reality |
|---|---|
| `--output=table   # human-readable table` | **no table format exists.** `internal/output/output.go` `ParseFormat` maps `yaml` and sends everything else to json, so `--output=table` silently returns json |
| `exec` documented as "plaintext, exit 1" | `cmd/exec/commands.go` uses `Run`, not `RunE` — the error goes to stderr and the process still **exits 0**. It also prints progress to **stdout** and polls `maxPollTime` (5 min, `cmd/project/ssh.go`) before failing |
| skill lives at `github.com/runpod/skills/tree/main/runpodctl` | repo renamed to `runpod-plugins-official`; the skill moved to `plugins/runpod/skills/runpodctl` |

<details>
<summary>verified against a build of this branch's base</summary>

```
$ runpodctl gpu list --output=table
[ { "available": true, ...          # json, exit 0, no warning

$ runpodctl exec python /etc/hosts --pod_id bogus-pod-id
warning: 'runpodctl exec' is deprecated; ...
Running remote Python shell...      # stdout
Waiting for Pod to come online...   # stdout, then polls 5 min
```

`grep -rn '"table"' --include='*.go' .` returns nothing, and `cmd/root.go` registers the flag as `output format (json, yaml)`.

</details>

## why now

Found while updating the runpodctl agent skill for the v2.8.0 output changes (runpod/runpod-plugins-official#41, CON-752). That work was supposed to use this README as its source, so the skill briefly inherited the `--output=table` error. The skill now documents the verified behavior; this PR removes the divergence rather than leaving the two to disagree.

CON-752
