### PR TITLE
fix: STO-330: Correctly mirror HF models for Model Repo

### DIFF
--- a/api/model.go
+++ b/api/model.go
@@ -172,6 +172,7 @@ type ModelVersionStatusMutationResult struct {
 type AddModelToRepoInput struct {
 	Owner               string                 `json:"owner,omitempty"`
 	Name                string                 `json:"name"`
+	HuggingFaceModel    string                 `json:"huggingFaceModel,omitempty"`
 	Provider            string                 `json:"provider,omitempty"`
 	CredentialType      string                 `json:"credentialType,omitempty"`
 	CredentialReference string                 `json:"credentialReference,omitempty"`
@@ -242,6 +243,7 @@ func AddModelToRepo(input *AddModelToRepoInput) (*Model, error) {
 	}
 
 	addString("owner", input.Owner)
+	addString("huggingFaceModel", input.HuggingFaceModel)
 	addString("provider", input.Provider)
 	addString("credentialType", input.CredentialType)
 	addString("credentialReference", input.CredentialReference)

--- a/api/model_test.go
+++ b/api/model_test.go
@@ -63,6 +63,69 @@ func TestAddModelToRepoSendsProviderWhenProvided(t *testing.T) {
 	}
 }
 
+func TestAddModelToRepoSendsHuggingFaceMirrorInput(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	var requestInput map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input Input
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		var ok bool
+		requestInput, ok = input.Variables["input"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected input variables, got %#v", input.Variables["input"])
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"addModelToRepo": map[string]interface{}{
+					"success": true,
+					"model": map[string]interface{}{
+						"id": "model-id", "owner": "user-id", "name": "Tiny-LLM", "provider": "LOCAL",
+						"versions": []map[string]interface{}{{"hash": "version-hash", "status": "PENDING_TRANSFER"}},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", server.URL)
+
+	model, err := AddModelToRepo(&AddModelToRepoInput{
+		Owner:            "destination-owner",
+		Name:             "tiny-llm",
+		HuggingFaceModel: "arnir0/Tiny-LLM",
+		Metadata:         map[string]interface{}{"purpose": "test"},
+	})
+	if err != nil {
+		t.Fatalf("AddModelToRepo returned error: %v", err)
+	}
+	if got := requestInput["huggingFaceModel"]; got != "arnir0/Tiny-LLM" {
+		t.Fatalf("expected huggingFaceModel in request, got %#v", got)
+	}
+	if got := requestInput["name"]; got != "tiny-llm" {
+		t.Fatalf("expected destination name in request, got %#v", got)
+	}
+	if got := requestInput["owner"]; got != "destination-owner" {
+		t.Fatalf("expected destination owner in request, got %#v", got)
+	}
+	if _, ok := requestInput["provider"]; ok {
+		t.Fatalf("did not expect provider in request, got %#v", requestInput)
+	}
+	metadata, ok := requestInput["metadata"].(map[string]interface{})
+	if !ok || metadata["purpose"] != "test" {
+		t.Fatalf("expected metadata in request, got %#v", requestInput["metadata"])
+	}
+	if len(model.Versions) != 1 || model.Versions[0].Hash != "version-hash" || model.Versions[0].Status != "PENDING_TRANSFER" {
+		t.Fatalf("expected returned pending transfer version, got %#v", model.Versions)
+	}
+}
+
 func TestGetModelsRequestsVersionIdentifiers(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)

--- a/cmd/model/addModelToRepo.go
+++ b/cmd/model/addModelToRepo.go
@@ -27,6 +27,7 @@ import (
 var (
 	addModelOwner               string
 	addModelName                string
+	addModelHuggingFaceModel    string
 	addModelCredentialReference string
 	addModelCredentialType      string
 	addModelStatus              string
@@ -158,7 +159,9 @@ var addCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	Short: "add a model",
 	Long:  "add a model to the runpod model repository",
-	RunE:  runAddModel,
+	Example: `  # --name is the destination; --huggingface-model is the source
+  runpodctl model add --name tiny-llm --huggingface-model arnir0/Tiny-LLM`,
+	RunE: runAddModel,
 }
 
 var AddModelToRepoCmd = &cobra.Command{
@@ -180,6 +183,7 @@ func init() {
 func bindAddModelFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&addModelOwner, "owner", "", "model owner namespace (user or team owner id)")
 	cmd.Flags().StringVar(&addModelName, "name", "", "model name")
+	cmd.Flags().StringVar(&addModelHuggingFaceModel, "huggingface-model", "", "hugging face model to mirror (owner/repo)")
 	cmd.Flags().StringVar(&addModelCredentialReference, "credential-reference", "", "credential reference (if required)")
 	cmd.Flags().StringVar(&addModelCredentialType, "credential-type", "", "credential type (if required)")
 	cmd.Flags().StringVar(&addModelStatus, "model-status", "", "initial model status")
@@ -195,16 +199,24 @@ func bindAddModelFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&addModelVerbose, "verbose", "v", false, "include upload details in wait-for-hash output")
 }
 
-// wantsUploadSession reports whether the flags ask for an upload session. Used
-// both for the pre-flight validation and for the post-create branch so the two
-// cannot drift apart (they previously differed by --metadata).
+func isHuggingFaceMirror() bool {
+	return strings.TrimSpace(addModelHuggingFaceModel) != ""
+}
+
+// wantsUploadSession reports whether the flags ask for a local upload session.
+// Metadata retains its legacy upload behavior except when it belongs to a
+// server-side Hugging Face mirror.
 func wantsUploadSession() bool {
 	return addModelCreateUpload || addModelFileName != "" || addModelFileSize != "" ||
-		addModelPartSize != "" || addModelContentType != "" || len(addModelMetadata) > 0
+		addModelPartSize != "" || addModelContentType != "" ||
+		(len(addModelMetadata) > 0 && !isHuggingFaceMirror())
 }
 
 func runAddModel(cmd *cobra.Command, args []string) error {
 	if err := setModelGraphQLTimeout(cmd); err != nil {
+		return err
+	}
+	if err := validateAddModelFlags(); err != nil {
 		return err
 	}
 
@@ -271,6 +283,7 @@ func runAddModel(cmd *cobra.Command, args []string) error {
 	input := &api.AddModelToRepoInput{
 		Owner:               addModelOwner,
 		Name:                addModelName,
+		HuggingFaceModel:    addModelHuggingFaceModel,
 		CredentialReference: addModelCredentialReference,
 		CredentialType:      addModelCredentialType,
 		ModelStatus:         addModelStatus,
@@ -361,6 +374,18 @@ func runAddModel(cmd *cobra.Command, args []string) error {
 	}
 
 	return printModelAddOutput(cmd, modelAddOutput{Model: model, Upload: result.Upload})
+}
+
+func validateAddModelFlags() error {
+	if !isHuggingFaceMirror() {
+		return nil
+	}
+
+	if addModelDirectoryPath != "" || addModelCreateUpload || addModelFileName != "" || addModelFileSize != "" || addModelPartSize != "" || addModelContentType != "" || addModelWaitForHash {
+		return fmt.Errorf("--huggingface-model cannot be combined with local upload flags")
+	}
+
+	return nil
 }
 
 func collectModelFiles(dir string) ([]modelFile, error) {

--- a/cmd/model/addModelToRepo_timeout_test.go
+++ b/cmd/model/addModelToRepo_timeout_test.go
@@ -336,6 +336,202 @@ func TestRunAddModelNonUploadLeavesProviderUnset(t *testing.T) {
 	}
 }
 
+func TestRunAddModelHuggingFaceMirrorUsesOnlyAddMutation(t *testing.T) {
+	resetAddModelGlobals(t)
+	oldAddModelToRepo := addModelToRepo
+	oldCreateModelRepoUpload := createModelRepoUpload
+	t.Cleanup(func() {
+		addModelToRepo = oldAddModelToRepo
+		createModelRepoUpload = oldCreateModelRepoUpload
+	})
+
+	addModelOwner = "destination-owner"
+	addModelName = "tiny-llm"
+	addModelHuggingFaceModel = "arnir0/Tiny-LLM"
+	addModelMetadata = map[string]string{"purpose": "test"}
+
+	var addInput *api.AddModelToRepoInput
+	addModelToRepo = func(input *api.AddModelToRepoInput) (*api.Model, error) {
+		copy := *input
+		addInput = &copy
+		return &api.Model{ID: "model-id", Owner: "destination-owner", Name: "tiny-llm", Provider: "LOCAL", Versions: []*api.ModelVersion{{Hash: "version-hash", Status: "PENDING_TRANSFER"}}}, nil
+	}
+	createModelRepoUpload = func(input *api.CreateModelRepoUploadInput) (*api.ModelRepoMutationResult, error) {
+		t.Fatal("mirror must not create an upload session")
+		return nil, nil
+	}
+
+	cmd := newTestAddModelCommand()
+	var runErr error
+	stdout, _ := captureStdStreams(t, func() { runErr = runAddModel(cmd, nil) })
+	if runErr != nil {
+		t.Fatalf("runAddModel returned error: %v", runErr)
+	}
+
+	if addInput == nil {
+		t.Fatal("expected addModelToRepo to be called")
+	}
+	if addInput.HuggingFaceModel != "arnir0/Tiny-LLM" {
+		t.Fatalf("expected hugging face model, got %q", addInput.HuggingFaceModel)
+	}
+	if addInput.Provider != "" {
+		t.Fatalf("expected mirror provider to be unset, got %q", addInput.Provider)
+	}
+	if addInput.Owner != "destination-owner" {
+		t.Fatalf("expected destination owner to pass through, got %q", addInput.Owner)
+	}
+	if got := addInput.Metadata["purpose"]; got != "test" {
+		t.Fatalf("expected mirror metadata to pass through, got %#v", addInput.Metadata)
+	}
+
+	var output modelAddOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if output.Model == nil || len(output.Model.Versions) != 1 {
+		t.Fatalf("expected returned mirror version, got %#v", output.Model)
+	}
+	if got := output.Model.Versions[0].Hash; got != "version-hash" {
+		t.Fatalf("expected mirror version hash, got %q", got)
+	}
+	if got := output.Model.Versions[0].Status; got != "PENDING_TRANSFER" {
+		t.Fatalf("expected mirror version status PENDING_TRANSFER, got %q", got)
+	}
+}
+
+func TestRunAddModelHuggingFaceMirrorOwnerIsOptional(t *testing.T) {
+	resetAddModelGlobals(t)
+	oldAddModelToRepo := addModelToRepo
+	oldCreateModelRepoUpload := createModelRepoUpload
+	t.Cleanup(func() {
+		addModelToRepo = oldAddModelToRepo
+		createModelRepoUpload = oldCreateModelRepoUpload
+	})
+
+	addModelName = "tiny-llm"
+	addModelHuggingFaceModel = "arnir0/Tiny-LLM"
+
+	addModelToRepo = func(input *api.AddModelToRepoInput) (*api.Model, error) {
+		if input.Owner != "" {
+			t.Fatalf("expected omitted destination owner, got %q", input.Owner)
+		}
+		return &api.Model{ID: "model-id", Name: "tiny-llm", Provider: "LOCAL"}, nil
+	}
+	createModelRepoUpload = func(input *api.CreateModelRepoUploadInput) (*api.ModelRepoMutationResult, error) {
+		t.Fatal("mirror must not create an upload session")
+		return nil, nil
+	}
+
+	var runErr error
+	captureStdStreams(t, func() { runErr = runAddModel(newTestAddModelCommand(), nil) })
+	if runErr != nil {
+		t.Fatalf("runAddModel returned error: %v", runErr)
+	}
+}
+
+func TestRunAddModelRejectsMirrorUploadCombinationsBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func()
+	}{
+		{name: "model path", setup: func() { addModelDirectoryPath = "model" }},
+		{name: "create upload", setup: func() { addModelCreateUpload = true }},
+		{name: "file name", setup: func() { addModelFileName = "weights.bin" }},
+		{name: "file size", setup: func() { addModelFileSize = "1" }},
+		{name: "part size", setup: func() { addModelPartSize = "1" }},
+		{name: "content type", setup: func() { addModelContentType = "application/octet-stream" }},
+		{name: "wait for hash", setup: func() { addModelWaitForHash = true }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetAddModelGlobals(t)
+			oldAddModelToRepo := addModelToRepo
+			oldCreateModelRepoUpload := createModelRepoUpload
+			t.Cleanup(func() {
+				addModelToRepo = oldAddModelToRepo
+				createModelRepoUpload = oldCreateModelRepoUpload
+			})
+
+			addModelHuggingFaceModel = "arnir0/Tiny-LLM"
+			tt.setup()
+			addModelToRepo = func(input *api.AddModelToRepoInput) (*api.Model, error) {
+				t.Fatal("invalid mirror flags must be rejected before addModelToRepo")
+				return nil, nil
+			}
+			createModelRepoUpload = func(input *api.CreateModelRepoUploadInput) (*api.ModelRepoMutationResult, error) {
+				t.Fatal("invalid mirror flags must be rejected before createModelRepoUpload")
+				return nil, nil
+			}
+
+			if err := runAddModel(newTestAddModelCommand(), nil); err == nil {
+				t.Fatal("expected incompatible flags error")
+			}
+		})
+	}
+}
+
+func TestRunAddModelMetadataWithoutMirrorStillRequestsUpload(t *testing.T) {
+	resetAddModelGlobals(t)
+	oldAddModelToRepo := addModelToRepo
+	t.Cleanup(func() { addModelToRepo = oldAddModelToRepo })
+
+	addModelName = "local-model"
+	addModelMetadata = map[string]string{"purpose": "test"}
+	addModelToRepo = func(input *api.AddModelToRepoInput) (*api.Model, error) {
+		t.Fatal("metadata-only upload must validate upload details before mutation")
+		return nil, nil
+	}
+
+	err := runAddModel(newTestAddModelCommand(), nil)
+	if err == nil || !strings.Contains(err.Error(), "file-name is required") {
+		t.Fatalf("expected metadata to retain local upload validation, got %v", err)
+	}
+}
+
+func TestRunAddModelLocalUploadWithMetadataRemainsUnchanged(t *testing.T) {
+	resetAddModelGlobals(t)
+	oldAddModelToRepo := addModelToRepo
+	oldCreateModelRepoUpload := createModelRepoUpload
+	t.Cleanup(func() {
+		addModelToRepo = oldAddModelToRepo
+		createModelRepoUpload = oldCreateModelRepoUpload
+	})
+
+	addModelName = "local-model"
+	addModelFileName = "weights.bin"
+	addModelFileSize = "10"
+	addModelMetadata = map[string]string{"purpose": "test"}
+
+	var addInput *api.AddModelToRepoInput
+	var uploadInput *api.CreateModelRepoUploadInput
+	addModelToRepo = func(input *api.AddModelToRepoInput) (*api.Model, error) {
+		copy := *input
+		addInput = &copy
+		return &api.Model{ID: "model-id", Name: "local-model", Provider: "LOCAL"}, nil
+	}
+	createModelRepoUpload = func(input *api.CreateModelRepoUploadInput) (*api.ModelRepoMutationResult, error) {
+		copy := *input
+		uploadInput = &copy
+		return &api.ModelRepoMutationResult{
+			Model:  &api.Model{ID: "model-id", Name: "local-model", Provider: "LOCAL"},
+			Upload: &api.ModelRepoUpload{SessionID: "session-id"},
+		}, nil
+	}
+
+	var runErr error
+	captureStdStreams(t, func() { runErr = runAddModel(newTestAddModelCommand(), nil) })
+	if runErr != nil {
+		t.Fatalf("runAddModel returned error: %v", runErr)
+	}
+	if addInput == nil || addInput.Provider != "LOCAL" || addInput.Metadata["purpose"] != "test" {
+		t.Fatalf("expected local add input with provider and metadata, got %#v", addInput)
+	}
+	if uploadInput == nil || uploadInput.Metadata["purpose"] != "test" {
+		t.Fatalf("expected local upload session with metadata, got %#v", uploadInput)
+	}
+}
+
 func TestUploadModelFilesUsesModelVersionUUIDAfterFirstFile(t *testing.T) {
 	oldCreateModelRepoUpload := createModelRepoUpload
 	oldCompleteModelUploadFile := completeModelUploadFile
@@ -738,6 +934,7 @@ func resetAddModelGlobals(t *testing.T) {
 
 	oldOwner := addModelOwner
 	oldName := addModelName
+	oldHuggingFaceModel := addModelHuggingFaceModel
 	oldCredentialReference := addModelCredentialReference
 	oldCredentialType := addModelCredentialType
 	oldStatus := addModelStatus
@@ -754,6 +951,7 @@ func resetAddModelGlobals(t *testing.T) {
 	t.Cleanup(func() {
 		addModelOwner = oldOwner
 		addModelName = oldName
+		addModelHuggingFaceModel = oldHuggingFaceModel
 		addModelCredentialReference = oldCredentialReference
 		addModelCredentialType = oldCredentialType
 		addModelStatus = oldStatus
@@ -771,6 +969,7 @@ func resetAddModelGlobals(t *testing.T) {
 
 	addModelOwner = ""
 	addModelName = ""
+	addModelHuggingFaceModel = ""
 	addModelCredentialReference = ""
 	addModelCredentialType = ""
 	addModelStatus = ""

--- a/cmd/model/getModels_test.go
+++ b/cmd/model/getModels_test.go
@@ -64,6 +64,9 @@ func TestModelCommandFlags(t *testing.T) {
 	if addCmd.Flags().Lookup("owner") == nil {
 		t.Fatal("expected model add --owner flag")
 	}
+	if addCmd.Flags().Lookup("huggingface-model") == nil {
+		t.Fatal("expected model add --huggingface-model flag")
+	}
 	if addCmd.Flags().Lookup("wait-for-hash") == nil {
 		t.Fatal("expected model add --wait-for-hash flag")
 	}

--- a/docs/runpodctl_model_add.md
+++ b/docs/runpodctl_model_add.md
@@ -10,6 +10,13 @@ add a model to the runpod model repository
 runpodctl model add [flags]
 ```
 
+### Examples
+
+```
+  # --name is the destination; --huggingface-model is the source
+  runpodctl model add --name tiny-llm --huggingface-model arnir0/Tiny-LLM
+```
+
 ### Options
 
 ```
@@ -21,6 +28,7 @@ runpodctl model add [flags]
       --file-size string              file size in bytes
       --hash-timeout duration         maximum duration to wait for --wait-for-hash (0 disables timeout) (default 30m0s)
   -h, --help                          help for add
+      --huggingface-model string      hugging face model to mirror (owner/repo)
       --metadata stringToString       metadata key=value pairs (default [])
       --model-path string             directory containing model files to upload
       --model-status string           initial model status
@@ -40,4 +48,3 @@ runpodctl model add [flags]
 ### SEE ALSO
 
 * [runpodctl model](runpodctl_model.md)	 - manage model repository
-

--- a/docs/runpodctl_model_remove.md
+++ b/docs/runpodctl_model_remove.md
@@ -29,4 +29,3 @@ runpodctl model remove [flags]
 ### SEE ALSO
 
 * [runpodctl model](runpodctl_model.md)	 - manage model repository
-

--- a/docs/runpodctl_serverless_update.md
+++ b/docs/runpodctl_serverless_update.md
@@ -47,4 +47,3 @@ runpodctl serverless update <endpoint-id> [flags]
 ### SEE ALSO
 
 * [runpodctl serverless](runpodctl_serverless.md)	 - manage serverless endpoints
-


### PR DESCRIPTION
Utilize newly added GQL for mirroring models from Huggingface to Model Repo