### PR TITLE
fix: sign and notarize macos binary (CON-787)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     concurrency: release-${{ github.ref }}
+    # quill waits for a conclusive notary verdict with no bound of its own;
+    # without this a stalled apple submission holds the concurrency lock for
+    # the default 6h and blocks any retry
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -36,8 +40,10 @@ jobs:
         with:
           go-version: "1.26.5"
 
+      # pinned: an unpinned installer makes releases non-reproducible and lets
+      # an upstream regression break signing without a change on our side
       - name: Install quill
-        run: curl -sSfL https://get.anchore.io/quill | sudo sh -s -- -b /usr/local/bin
+        run: curl -sSfL https://get.anchore.io/quill | sudo sh -s -- -b /usr/local/bin v0.7.1
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           go-version: "1.26.5"
 
+      - name: Install quill
+        run: curl -sSfL https://get.anchore.io/quill | sudo sh -s -- -b /usr/local/bin
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -44,6 +47,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ steps.app-token.outputs.token }}
+          QUILL_SIGN_P12: ${{ secrets.QUILL_SIGN_P12 }}
+          QUILL_SIGN_PASSWORD: ${{ secrets.QUILL_SIGN_PASSWORD }}
+          QUILL_NOTARY_KEY: ${{ secrets.QUILL_NOTARY_KEY }}
+          QUILL_NOTARY_KEY_ID: ${{ secrets.QUILL_NOTARY_KEY_ID }}
+          QUILL_NOTARY_ISSUER: ${{ secrets.QUILL_NOTARY_ISSUER }}
 
   # Linear release tracking. Only runs for tag pushes, not manual dispatch.
   linear-sync:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,21 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     concurrency: release-${{ github.ref }}
-    # quill waits for a conclusive notary verdict with no bound of its own;
-    # without this a stalled apple submission holds the concurrency lock for
-    # the default 6h and blocks any retry
+    # belt and braces over quill's own notary bound, which is already firm:
+    # notary.PollStatus wraps the poll loop in context.WithTimeout, and
+    # status.timeout-seconds defaults to 900s. this only keeps a hang elsewhere
+    # in the job (build, upload, tap pr) from holding the concurrency lock for
+    # the default 6h and blocking a retry.
+    #
+    # quill's 900s notary timeout has a hard ceiling above it: quill mints one
+    # app store connect jwt up front with exp = timeout + 2m and never refreshes
+    # it (quill/notarize.go WithStatusConfig -> notary.NewSignedToken), and apple
+    # rejects notary tokens with a lifetime over 20 minutes. so anything above
+    # 1080s (18m) is a guaranteed 401 -- the 2400s that looks reasonable for a
+    # slow first submission cannot work. if apple does exceed the timeout,
+    # re-run the workflow; quill has no resume, so it re-signs and resubmits
+    # from scratch (and each signing run embeds a fresh apple timestamp, so the
+    # bytes and the hash differ every time).
     timeout-minutes: 45
 
     steps:
@@ -40,15 +52,42 @@ jobs:
         with:
           go-version: "1.26.5"
 
-      # pinned: an unpinned installer makes releases non-reproducible and lets
-      # an upstream regression break signing without a change on our side
+      # the release tarball is pinned by version *and* sha256, and installed
+      # without piping anything to a shell. this job receives the developer id
+      # p12 and the notary key, so an unverified installer running as root here
+      # is a direct exfiltration path for the signing identity. the checksum
+      # also makes an upstream regression a loud install failure rather than a
+      # quietly different signature.
+      # bump both values together, from quill_<version>_checksums.txt.
+      # names are deliberately not QUILL_*: quill itself reads QUILL_<section>_<key>
+      # from the environment, so keeping install vars out of that prefix stops a
+      # future rename from silently reconfiguring the signer.
       - name: Install quill
-        run: curl -sSfL https://get.anchore.io/quill | sudo sh -s -- -b /usr/local/bin v0.7.1
+        env:
+          PIN_QUILL_VERSION: 0.7.1
+          PIN_QUILL_SHA256: e58c6f86378a22507c1123e24412afd4ee2d3bb32ebd94d6059827dc0c1b3fbf
+        run: |
+          set -euo pipefail
+          # a scratch dir, not the workspace: goreleaser's non-snapshot run fails
+          # on a dirty git tree, so a leftover download would break the release
+          # with an unrelated error message.
+          workdir="$(mktemp -d)"
+          tarball="${workdir}/quill_${PIN_QUILL_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL --retry 3 -o "$tarball" \
+            "https://github.com/anchore/quill/releases/download/v${PIN_QUILL_VERSION}/quill_${PIN_QUILL_VERSION}_linux_amd64.tar.gz"
+          echo "${PIN_QUILL_SHA256}  ${tarball}" | sha256sum --check --strict -
+          tar -xzf "$tarball" -C "$workdir" quill
+          sudo install -m 0755 "${workdir}/quill" /usr/local/bin/quill
+          rm -rf "$workdir"
+          quill version
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          # pinned now that goreleaser drives signing: with `latest`, an upstream
+          # release can change the signing chain (hook ordering, universal binary
+          # handling) between two tags of ours with no change on our side.
+          version: v2.17.1
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,13 +41,18 @@ upx:
 universal_binaries:
   - id: default
     replace: true
-    # sign + notarize after lipo merges the per-arch builds; signing before the
-    # merge produces an invalid signature. snapshots ad-hoc sign and skip the
-    # notary submission so local builds need no credentials.
+    # sign + notarize after the per-arch builds are merged into the fat binary;
+    # signing before the merge produces an invalid signature. snapshots ad-hoc
+    # sign and skip the notary submission so local builds need no credentials.
     hooks:
       post:
-        # output: true so quill's notary submission id and rejection reasons
-        # reach the job log — goreleaser swallows hook output otherwise
+        # output: true streams quill's progress live. it is not what surfaces a
+        # rejection: goreleaser buffers hook output and attaches it to the error
+        # anyway, and quill already puts apple's rejection log in the error it
+        # returns. quill logs the submission id at trace only, so to query a past
+        # submission by hand use `quill submission list` rather than raising the
+        # log level here (trace logging on a job holding the signing identity is
+        # not worth the id).
         - cmd: quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }}
           output: true
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,12 @@ upx:
 universal_binaries:
   - id: default
     replace: true
+    # sign + notarize after lipo merges the per-arch builds; signing before the
+    # merge produces an invalid signature. snapshots ad-hoc sign and skip the
+    # notary submission so local builds need no credentials.
+    hooks:
+      post:
+        - cmd: quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }}
 
 archives:
   - id: default

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,10 @@ universal_binaries:
     # notary submission so local builds need no credentials.
     hooks:
       post:
+        # output: true so quill's notary submission id and rejection reasons
+        # reach the job log — goreleaser swallows hook output otherwise
         - cmd: quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }}
+          output: true
 
 archives:
   - id: default

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ releases are fully automated by [goreleaser](https://goreleaser.com/) via the `r
 
 3. the tag push triggers the `release` workflow, which runs `goreleaser release --clean` and:
    - builds binaries for darwin/linux/windows (amd64/arm64), incl. raw `runpodctl-{os}-{arch}` binaries for the legacy self-update command and a upx-compressed linux/amd64 build.
+   - signs and notarizes the darwin universal binary with [quill](https://github.com/anchore/quill), after the per-arch builds are merged into the fat binary and before archiving, so the release checksums and the homebrew formula/cask hashes all cover the signed artifact. the raw per-arch `runpodctl-darwin-{arch}` binaries are **not** signed; only pre-signing runpodctl versions fetch those.
    - creates the github release with archives + checksums (prereleases are auto-detected from the tag).
    - opens pull requests on [runpod/homebrew-runpodctl](https://github.com/runpod/homebrew-runpodctl) for the homebrew formula and cask.
 
@@ -228,6 +229,15 @@ releases are fully automated by [goreleaser](https://goreleaser.com/) via the `r
 notes:
 
 - the workflow can also be run manually via `workflow_dispatch` (re-runs goreleaser against the current ref).
+- running goreleaser locally needs `quill` on your `PATH` (see [quill's install instructions](https://github.com/anchore/quill#installation); the workflow's install step is pinned to linux/amd64, so copy the version but not the tarball name), because the darwin signing hook also runs for snapshots. snapshots sign ad-hoc and skip the notary submission, so no apple credentials are needed:
+
+  ```bash
+  goreleaser release --snapshot --clean
+  ```
+
+- signing/notarization uses the `QUILL_SIGN_P12`, `QUILL_SIGN_PASSWORD`, `QUILL_NOTARY_KEY`, `QUILL_NOTARY_KEY_ID` and `QUILL_NOTARY_ISSUER` secrets. a signing or notary failure fails the whole release before anything is published.
+- quill waits up to 15 minutes (900s) for apple's verdict and then fails. that timeout cannot be raised much: quill mints a single app store connect token with `exp = timeout + 2m` and never refreshes it, and apple rejects notary tokens whose lifetime exceeds 20 minutes — so anything above 1080s (18m) is a guaranteed 401. if apple is slow enough to trip the timeout, re-run the workflow; quill has no resume, so it re-signs and resubmits from scratch (each signing run embeds a fresh apple timestamp, so the hash differs every run).
+- the signed binary is not stapled (quill cannot staple a bare mach-o). that only matters for downloads that carry the quarantine bit (a browser download, or `brew install --cask`): there gatekeeper does an online notarization check on first run. a `curl` download or the homebrew formula sets no quarantine bit, so gatekeeper never checks.
 - the homebrew prs are authored by a github app; tap auth uses the `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` secrets, and goreleaser pushes via the generated `HOMEBREW_TAP_TOKEN`.
 - conda-forge is updated separately by the conda-forge feedstock bot, not by this workflow.
 


### PR DESCRIPTION
macOS binaries ship with only the ad-hoc signature the Go linker emits — `TeamIdentifier` unset, `Signature=adhoc`, `spctl` verdict `rejected`. Gatekeeper refuses to run them; the brew cask path fails loudest, as *"the application is damaged and can't be opened."*

All four macOS install paths (brew formula, brew cask, `install.sh`, `runpodctl update`) fetch `runpodctl-darwin-all.tar.gz`, so signing that one artifact fixes all four.

## Changes

- `.goreleaser.yml` — `quill sign-and-notarize` post-hook on `universal_binaries`, after `lipo` merges the per-arch builds. `output: true` so quill's notary submission id and rejection reasons reach the job log; GoReleaser swallows hook stdout otherwise.
- `release.yml` — install quill (pinned to `v0.7.1`), pass five `QUILL_*` secrets to GoReleaser, and bound the job at `timeout-minutes: 45`.

Snapshots ad-hoc sign and skip notary submission (`--dry-run={{ .IsSnapshot }}`), so local builds need no credentials. Job stays on `ubuntu-latest` — quill signs and notarizes Mach-O from Linux.

The timeout matters because quill waits for a conclusive notary verdict with no bound of its own: a stalled Apple submission would otherwise hold the `release-${ref}` concurrency lock for the default 6h and block any retry.

## Verification

<details>
<summary>Snapshot build passes; hooks inherit job env; the real universal binary signs valid against the production cert</summary>

`goreleaser release --snapshot --clean` → exit 0, hook fires on the merged binary and its output is now visible:

```
• universal binaries
  • creating from 2 binaries    id=default binary=dist/default_darwin_all/runpodctl
  • running hook                hook=quill sign-and-notarize "dist/default_darwin_all/runpodctl" --dry-run=true --ad-hoc=true
    │ [0000]  WARN only ad-hoc signing ...
    │ [0000]  WARN DRY RUN: skipping notarization...
```

GoReleaser hooks inherit the job environment — verified with a sentinel variable in an isolated project, since that is how the five secrets reach quill:

```
• running hook   hook=sh -c 'echo "HOOK SEES SENTINEL=[$SENTINEL_VAR]"'
  │ HOOK SEES SENTINEL=[leaked-into-hook]
```

Same universal artifact signed with the real Developer ID `.p12`:

```
Authority=Developer ID Application: Runpod, Inc. (YM4PQ356FQ)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
TeamIdentifier=YM4PQ356FQ

codesign --verify --deep --strict:
  valid on disk
  satisfies its Designated Requirement
```

Not yet exercised: the live Apple notary round-trip, which only runs on a real tag. Watch the first tagged release.

</details>

## Notes

- Signing is not retroactive — existing v2.3.0 artifacts stay unsigned. A new tag is required after merge.
- Certificate is Developer ID Application, G2 Sub-CA, valid to 2031-07-31. Previous Sub-CA certs would have expired 2027-02-01.
- Fails closed: notarization failure aborts during the build stage, before the GitHub release or tap PR exist. No half-published release.
- `upx` stays scoped to `linux_amd64` — it rewrites the Mach-O and would destroy the signature.
- Bare binaries in `.tar.gz` can't be stapled (`xcrun stapler` is `.app`/`.dmg`/`.pkg` only), so Gatekeeper does an online ticket lookup. Expected.
- The `legacy` per-arch darwin binaries remain unsigned. Only pre-change clients self-update via those; current `update.go` and `install.sh` both use `darwin-all`. Unchanged by this PR.

Does not fix: Homebrew tap trust (`HOMEBREW_REQUIRE_TAP_TRUST`) or self-update checksum verification ([API-318](https://linear.app/runpod/issue/API-318)). Both orthogonal.

[CON-787](https://linear.app/runpod/issue/CON-787/fix-runpodctl-homebrew-install-on-macos)