### PR TITLE
fix: don't drop networkVolume and networkVolumeId in pod get

### DIFF
--- a/cmd/pod/get_test.go
+++ b/cmd/pod/get_test.go
@@ -1,0 +1,112 @@
+package pod
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/runpod/runpodctl/internal/api"
+	"github.com/spf13/cobra"
+)
+
+func TestRunGetPrintsIncludedNetworkVolume(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pods/pod-123" {
+			// fetchPodDetails degrades gracefully when its optional GraphQL
+			// enrichment is unavailable. Keep that request local to this test.
+			http.Error(w, "graphql unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if got := r.URL.Query().Get("includeNetworkVolume"); got != "true" {
+			t.Errorf("expected includeNetworkVolume=true, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "pod-123",
+			"name": "my-pod",
+			"networkVolumeId": "vol-123",
+			"networkVolume": {
+				"id": "vol-123",
+				"name": "my-volume",
+				"dataCenterId": "US-TX-1",
+				"size": 10
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+	t.Setenv("RUNPOD_API_URL", server.URL)
+	t.Setenv("RUNPOD_GRAPHQL_URL", server.URL)
+
+	oldIncludeMachine := getIncludeMachine
+	oldIncludeNetworkVolume := getIncludeNetworkVolume
+	getIncludeMachine = false
+	getIncludeNetworkVolume = true
+	t.Cleanup(func() {
+		getIncludeMachine = oldIncludeMachine
+		getIncludeNetworkVolume = oldIncludeNetworkVolume
+	})
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("output", "json", "")
+
+	printed, err := capturePodGetStdout(func() error {
+		return runGet(cmd, []string{"pod-123"})
+	})
+	if err != nil {
+		t.Fatalf("run pod get: %v", err)
+	}
+
+	var got struct {
+		NetworkVolumeID string             `json:"networkVolumeId"`
+		NetworkVolume   *api.NetworkVolume `json:"networkVolume"`
+	}
+	if err := json.Unmarshal(printed, &got); err != nil {
+		t.Fatalf("decode pod get output: %v\noutput: %s", err, printed)
+	}
+	if got.NetworkVolumeID != "vol-123" {
+		t.Errorf("expected networkVolumeId vol-123, got %q", got.NetworkVolumeID)
+	}
+	if got.NetworkVolume == nil {
+		t.Fatalf("network volume missing from pod get output: %s", printed)
+	}
+	if got.NetworkVolume.ID != "vol-123" {
+		t.Errorf("expected volume id vol-123, got %q", got.NetworkVolume.ID)
+	}
+	if got.NetworkVolume.Name != "my-volume" {
+		t.Errorf("expected volume name my-volume, got %q", got.NetworkVolume.Name)
+	}
+	if got.NetworkVolume.DataCenterID != "US-TX-1" {
+		t.Errorf("expected data center US-TX-1, got %q", got.NetworkVolume.DataCenterID)
+	}
+	if got.NetworkVolume.Size != 10 {
+		t.Errorf("expected volume size 10, got %d", got.NetworkVolume.Size)
+	}
+}
+
+func capturePodGetStdout(run func() error) ([]byte, error) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	original := os.Stdout
+	os.Stdout = writer
+	runErr := run()
+	closeErr := writer.Close()
+	os.Stdout = original
+
+	printed, readErr := io.ReadAll(reader)
+	_ = reader.Close()
+	if runErr != nil {
+		return printed, runErr
+	}
+	if closeErr != nil {
+		return printed, closeErr
+	}
+	return printed, readErr
+}

--- a/internal/api/pods.go
+++ b/internal/api/pods.go
@@ -27,7 +27,7 @@ type Pod struct {
 	DockerEntrypoint  []string               `json:"dockerEntrypoint,omitempty"`
 	CostPerHr         float64                `json:"costPerHr,omitempty"`
 	NetworkVolumeID   string                 `json:"networkVolumeId,omitempty"`
-	NetworkVolume     map[string]interface{} `json:"networkVolume,omitempty"`
+	NetworkVolume     *NetworkVolume         `json:"networkVolume,omitempty"`
 	Machine           map[string]interface{} `json:"machine,omitempty"`
 	Runtime           map[string]interface{} `json:"runtime,omitempty"`
 	Env               map[string]string      `json:"env,omitempty"`

--- a/internal/api/pods.go
+++ b/internal/api/pods.go
@@ -26,6 +26,8 @@ type Pod struct {
 	DockerStartCmd    []string               `json:"dockerStartCmd,omitempty"`
 	DockerEntrypoint  []string               `json:"dockerEntrypoint,omitempty"`
 	CostPerHr         float64                `json:"costPerHr,omitempty"`
+	NetworkVolumeID   string                 `json:"networkVolumeId,omitempty"`
+	NetworkVolume     map[string]interface{} `json:"networkVolume,omitempty"`
 	Machine           map[string]interface{} `json:"machine,omitempty"`
 	Runtime           map[string]interface{} `json:"runtime,omitempty"`
 	Env               map[string]string      `json:"env,omitempty"`

--- a/internal/api/pods_test.go
+++ b/internal/api/pods_test.go
@@ -94,6 +94,96 @@ func TestGetPod(t *testing.T) {
 	}
 }
 
+func TestGetPod_IncludeNetworkVolumeSurvivesToOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("includeNetworkVolume"); got != "true" {
+			t.Errorf("expected includeNetworkVolume=true, got %q", r.URL.RawQuery)
+		}
+		w.Write([]byte(`{
+			"id": "pod-123",
+			"name": "my-pod",
+			"networkVolumeId": "vol-123",
+			"networkVolume": {
+				"id": "vol-123",
+				"name": "my-volume",
+				"dataCenterId": "US-TX-1",
+				"size": 10
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	client, _ := NewClient()
+	client.baseURL = server.URL
+
+	pod, err := client.GetPod("pod-123", false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	printed, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(printed, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got["networkVolumeId"] != "vol-123" {
+		t.Errorf("expected networkVolumeId vol-123, got %v", got["networkVolumeId"])
+	}
+
+	volume, ok := got["networkVolume"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("network volume missing from pod output: %s", printed)
+	}
+	if volume["name"] != "my-volume" {
+		t.Errorf("expected my-volume, got %v", volume["name"])
+	}
+	if volume["dataCenterId"] != "US-TX-1" {
+		t.Errorf("expected US-TX-1, got %v", volume["dataCenterId"])
+	}
+	if volume["size"] != float64(10) {
+		t.Errorf("expected size 10, got %v", volume["size"])
+	}
+}
+
+func TestGetPod_OmitsNetworkVolumeWhenAbsent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"id": "pod-123", "name": "my-pod"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	client, _ := NewClient()
+	client.baseURL = server.URL
+
+	pod, err := client.GetPod("pod-123", false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	printed, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(printed, &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, present := got["networkVolumeId"]; present {
+		t.Errorf("expected networkVolumeId to be omitted for a pod without a network volume, got %s", printed)
+	}
+	if _, present := got["networkVolume"]; present {
+		t.Errorf("expected networkVolume to be omitted for a pod without a network volume, got %s", printed)
+	}
+}
+
 func TestCreatePod(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {


### PR DESCRIPTION
## Summary

`runpodctl pod get $pod --include-network-volume` does not actually return network volume info despite passing the required params to the underlying REST API. The root cause is that the `Pod` struct is missing these fields, so they are discarded upon deserialization. This PR adds the missing fields and closes #291.

## Testing

I created a pod `nsr02fbf61si3n` with a network volume attached. Without the change, `runpodctl pod get nsr02fbf61si3n --include-network-volume | jq '.networkVolume'` returns `null`. With the change, `bin/runpodctl pod get nsr02fbf61si3n --include-network-volume | jq '.networkVolume'` returns
```json
{
  "dataCenterId": "EU-CZ-1",
  "id": "niq6cdm1yy",
  "name": "principal_pink_tern",
  "size": 10
}
```

Note that with the change, `pod get` always returns a `networkVolumeId` (if a network volume is present) whether `--include-network-volume` is passed or not. I believe this is the desired behaviour since the inclusion of the `networkVolumeId` comes for free.

## Related issue

While investigating this issue, I discovered another bug: `uptimeSeconds` seems to always be zero. Pod `nsr02fbf61si3n` has an uptime of over an hour, yet `runpodctl pod get nsr02fbf61si3n | jq '.uptimeSeconds'` returns `0`. I believe the root cause is that the GraphQL API returns
```json
{ "uptimeSeconds": 0, "runtime": { "uptimeInSeconds": 4026 } }
```
but the CLI takes `uptimeSeconds` instead of `runtime.uptimeInSeconds`.