### PR TITLE
docs: fix windows powershell install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ $dest = "$env:LOCALAPPDATA\runpodctl"
 Invoke-WebRequest -UseBasicParsing -Uri https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-amd64.zip -OutFile "$env:TEMP\runpodctl.zip"
 Expand-Archive -Force -Path "$env:TEMP\runpodctl.zip" -DestinationPath $dest
 $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
-if ($userPath -notlike "*$dest*") {
-  [Environment]::SetEnvironmentVariable('Path', "$userPath;$dest", 'User')
+$pathEntries = @($userPath -split ';' | Where-Object { $_ })
+if ($pathEntries -notcontains $dest) {
+  [Environment]::SetEnvironmentVariable('Path', (($pathEntries + $dest) -join ';'), 'User')
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ _note: all pods automatically come with runpodctl installed with a pod-scoped ap
 
 ### install
 
+the canonical install guide, with every platform and the full notes, lives at
+[docs.runpod.io/runpodctl/overview](https://docs.runpod.io/runpodctl/overview).
+keep the two in step when either changes.
+
 #### linux/macos (wsl)
 
 ```bash
@@ -51,9 +55,20 @@ brew install runpod/runpodctl/runpodctl
 
 #### windows powershell
 
+installs to `%LOCALAPPDATA%\runpodctl` and puts it on your `PATH`, so `runpodctl`
+works from any terminal. for arm64, swap `amd64` for `arm64` in the url.
+
 ```powershell
-Invoke-WebRequest -Uri https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-amd64.exe -OutFile runpodctl.exe
+$dest = "$env:LOCALAPPDATA\runpodctl"
+Invoke-WebRequest -UseBasicParsing -Uri https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-amd64.zip -OutFile "$env:TEMP\runpodctl.zip"
+Expand-Archive -Force -Path "$env:TEMP\runpodctl.zip" -DestinationPath $dest
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($userPath -notlike "*$dest*") {
+  [Environment]::SetEnvironmentVariable('Path', "$userPath;$dest", 'User')
+}
 ```
+
+then open a new terminal so the `PATH` change takes effect.
 
 #### conda, mamba, pixi (conda-forge)
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ brew install runpod/runpodctl/runpodctl
 #### windows powershell
 
 ```powershell
-wget https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-amd64.exe -O runpodctl.exe
+Invoke-WebRequest -Uri https://github.com/runpod/runpodctl/releases/latest/download/runpodctl-windows-amd64.exe -OutFile runpodctl.exe
 ```
 
 #### conda, mamba, pixi (conda-forge)

--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ _note: all pods automatically come with runpodctl installed with a pod-scoped ap
 
 ### install
 
-the canonical install guide, with every platform and the full notes, lives at
-[docs.runpod.io/runpodctl/overview](https://docs.runpod.io/runpodctl/overview).
-keep the two in step when either changes.
-
 #### linux/macos (wsl)
 
 ```bash


### PR DESCRIPTION
Closes #311

## Context

The README's Windows install snippet was copied from the Linux one:

```powershell
wget https://github.com/.../runpodctl-windows-amd64.exe -O runpodctl.exe
```

On Linux, `wget` is a download tool and `-O` means "save as this filename."

## The issue

On Windows, `wget` is not that tool. PowerShell aliases `wget` to its own `Invoke-WebRequest`, which has no `-O` parameter. PowerShell allows abbreviated parameter names only when unambiguous, and `-O` matches four (`-OutFile`, `-OutVariable`, `-OutBuffer`, `-OperationTimeoutSeconds`), so it refuses:

```
Parameter cannot be processed because the parameter name 'O' is ambiguous.
```

Nothing downloads. The documented Windows install path has been broken since January 2024 (`3da74ab`).

A second, older problem showed up while fixing it: even when the download worked, it dropped a bare exe into the current directory with no `PATH` entry. macOS and Linux users get a working `runpodctl` command; Windows users had to `cd` to that folder and type `.\runpodctl.exe`.

## The fix

- Use `Invoke-WebRequest` with the full `-OutFile` name. Correct on Windows PowerShell 5.1, and on PowerShell 6+ where the `wget` alias no longer exists at all.
- Install properly: download the zip, expand to `%LOCALAPPDATA%\runpodctl`, add that to the user `PATH`. `runpodctl` then works from any terminal.
- Document the `amd64`→`arm64` swap, and the "open a new terminal" step.
- Link [docs.runpod.io/runpodctl/overview](https://docs.runpod.io/runpodctl/overview) as the canonical install guide, so the README is not the thing that silently drifts.

## One deliberate difference from the skills-repo guide

The zip-plus-PATH approach is taken from the install guide in the runpod skills repo, but the `PATH` handling here **intentionally differs**. That guide does:

```powershell
[Environment]::SetEnvironmentVariable('Path', $env:Path + ";$env:LOCALAPPDATA\runpodctl", 'User')
```

`$env:Path` is the *process* PATH, which already contains the machine entries. Writing it back into the **User** variable copies the system PATH into it permanently, and appends a duplicate on every re-run. This PR reads the User PATH directly and guards with `-notlike`.

`-UseBasicParsing` is defensive only: `Invoke-WebRequest` on Windows PowerShell 5.1 can fail with "the Internet Explorer engine is not available…" on fresh installs and Server Core. I have not reproduced that failure, and it may not apply when `-OutFile` is used. The switch is a no-op on PowerShell 6+, so it costs nothing either way.

## Verification

- Downloaded and listed both `runpodctl-windows-amd64.zip` and `runpodctl-windows-arm64.zip`: each contains `runpodctl.exe` at the root, so `-DestinationPath` and the `PATH` entry are correct and the documented arm64 swap works.
- The asset URL returns 200.

**Not verified on Windows.** No Windows machine or CI runner is available, and the bug only reproduces on Windows PowerShell 5.1 where the `wget` alias exists. The above is artifact inspection and reasoning, not execution — please paste the snippet into a Windows terminal once before merging.

---

## Related PRs

Two independent groups. Nothing in one blocks anything in the other.

### Group A — the Windows install command (runpod/runpodctl#311)

One broken command that had been copy-pasted into three repos. Each PR fixes its own copy; **any order, no dependencies.**

| PR | Repo | Change |
|---|---|---|
| runpod/runpodctl#328 ← **this PR** | runpodctl | `README.md` — fix the command, and install to `PATH` |
| runpod/docs#805 | docs | `runpodctl/overview.mdx` — same fix on docs.runpod.io |
| runpod/runpod-plugins-official#49 | plugins | delete `reference/install.md`, the third copy |

### Group B — secure registry passwords (runpod/runpodctl#327)

**Order matters.** #51 documents a flag that does not exist on `main` until #329 merges, so it stays draft until then.

| # | PR | Repo | Change |
|---|---|---|---|
| 1 | runpod/runpodctl#329 | runpodctl | `--password-stdin`, no-echo prompt, mutually exclusive flags |
| 2 | runpod/runpod-plugins-official#51 | plugins | skill guidance + regression eval (**draft** until #329 lands) |

The only thing the two groups share is that both touched the runpodctl skill, which is what prompted Group A's deletion: the skill had been keeping its own copy of install instructions the runpodctl README already owned.