### PR TITLE
feat(registry): read the registry password from stdin

### DIFF
--- a/cmd/registry/create.go
+++ b/cmd/registry/create.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/runpod/runpodctl/internal/api"
 	"github.com/runpod/runpodctl/internal/clierr"
@@ -58,8 +60,36 @@ func init() {
 // promptPassword is a package variable so tests can exercise the prompt branch
 // without a controlling terminal.
 var promptPassword = func(stderr io.Writer) (string, error) {
+	fd := int(os.Stdin.Fd())
+
+	// ReadPassword disables echo and restores it from a deferred ioctl, which a
+	// signal's default disposition never reaches: a ctrl-c at the prompt would
+	// kill the process with echo still off and leave the caller's shell typing
+	// blind until they ran `stty sane`. Restore it from a handler instead.
+	state, err := term.GetState(fd)
+	if err != nil {
+		return "", fmt.Errorf("failed to read the terminal state: %w", err)
+	}
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-sigCh:
+			_ = term.Restore(fd, state)
+			fmt.Fprintln(stderr)
+			// 128 + SIGINT, the shell convention for "died on a signal". The
+			// deferred restores below are deliberately skipped: the terminal is
+			// already back and there is nothing else to unwind at a prompt.
+			os.Exit(130)
+		case <-done:
+		}
+	}()
+
 	fmt.Fprint(stderr, "registry password: ")
-	secret, err := term.ReadPassword(int(os.Stdin.Fd()))
+	secret, err := term.ReadPassword(fd)
 	// ReadPassword swallows the user's newline, so the next line of output would
 	// otherwise start on the prompt line.
 	fmt.Fprintln(stderr)
@@ -86,17 +116,14 @@ func resolvePassword(stdin io.Reader, stderr io.Writer, flagValue string, fromSt
 		if err != nil {
 			return "", fmt.Errorf("failed to read the password from stdin: %w", err)
 		}
-		// strip only the trailing line ending a pipe or heredoc adds. leading and
-		// inner whitespace can be part of the credential and must survive.
+		// strip only the trailing line ending a pipe or heredoc adds. everything
+		// else survives: a gcr.io / artifact registry credential is a whole
+		// service-account json key (username _json_key), so the value is
+		// legitimately multi-line, and the api accepts it. leading and inner
+		// whitespace can be significant too.
 		secret := strings.TrimSuffix(strings.TrimSuffix(string(data), "\n"), "\r")
 		if secret == "" {
 			return "", clierr.Usagef("the password read from stdin is empty")
-		}
-		// a token never spans lines, so this is a redirected file with extra
-		// content rather than a credential. the api would reject it with a less
-		// obvious error.
-		if strings.ContainsAny(secret, "\r\n") {
-			return "", clierr.Usagef("the password read from stdin spans multiple lines")
 		}
 		return secret, nil
 

--- a/cmd/registry/create.go
+++ b/cmd/registry/create.go
@@ -25,7 +25,7 @@ the password can come from --password, from stdin with --password-stdin, or from
 an interactive prompt when neither flag is given. --password-stdin keeps the
 credential out of the process table and your shell history.`,
 	Example: `  # read the password from a pipe
-  echo "$REGISTRY_TOKEN" | runpodctl registry create --name ghcr --username me --password-stdin
+  printenv REGISTRY_TOKEN | runpodctl registry create --name ghcr --username me --password-stdin
 
   # read it from a file without exposing it to the process table
   runpodctl registry create --name ghcr --username me --password-stdin < token.txt
@@ -71,7 +71,7 @@ var promptPassword = func(stderr io.Writer) (string, error) {
 		return "", fmt.Errorf("failed to read the terminal state: %w", err)
 	}
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 	defer signal.Stop(sigCh)
 	done := make(chan struct{})
 	defer close(done)
@@ -156,12 +156,15 @@ func resolvePassword(stdin io.Reader, stderr io.Writer, flagValue string, fromSt
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
-	password, err := resolvePassword(cmd.InOrStdin(), cmd.ErrOrStderr(), createPassword, createPasswordStdin)
+	// build the client before touching the password sources: a missing api key
+	// should fail here, not after consuming a one-shot stdin secret or making the
+	// user type a password that can never be submitted.
+	client, err := api.NewClient()
 	if err != nil {
 		return err
 	}
 
-	client, err := api.NewClient()
+	password, err := resolvePassword(cmd.InOrStdin(), cmd.ErrOrStderr(), createPassword, createPasswordStdin)
 	if err != nil {
 		return err
 	}

--- a/cmd/registry/create.go
+++ b/cmd/registry/create.go
@@ -77,13 +77,14 @@ var promptPassword = func(stderr io.Writer) (string, error) {
 	defer close(done)
 	go func() {
 		select {
-		case <-sigCh:
+		case sig := <-sigCh:
 			_ = term.Restore(fd, state)
 			fmt.Fprintln(stderr)
-			// 128 + SIGINT, the shell convention for "died on a signal". The
-			// deferred restores below are deliberately skipped: the terminal is
-			// already back and there is nothing else to unwind at a prompt.
-			os.Exit(130)
+			// 128 + the signal number is the shell convention for "died on a
+			// signal". The deferred restores below are deliberately skipped: the
+			// terminal is already back and there is nothing else to unwind at a
+			// prompt.
+			os.Exit(signalExitCode(sig))
 		case <-done:
 		}
 	}()
@@ -97,6 +98,13 @@ var promptPassword = func(stderr io.Writer) (string, error) {
 		return "", fmt.Errorf("failed to read the password from the terminal: %w", err)
 	}
 	return string(secret), nil
+}
+
+func signalExitCode(sig os.Signal) int {
+	if signalNumber, ok := sig.(syscall.Signal); ok {
+		return 128 + int(signalNumber)
+	}
+	return 1
 }
 
 // stdinIsTerminal reports whether stdin is a terminal we can prompt on, as

--- a/cmd/registry/create.go
+++ b/cmd/registry/create.go
@@ -2,38 +2,132 @@ package registry
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"strings"
 
 	"github.com/runpod/runpodctl/internal/api"
+	"github.com/runpod/runpodctl/internal/clierr"
 	"github.com/runpod/runpodctl/internal/output"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "create a new registry auth",
-	Long:  "create a new container registry authentication",
-	Args:  cobra.NoArgs,
-	RunE:  runCreate,
+	Long: `create a new container registry authentication
+
+the password is a long-lived credential, so prefer --password-stdin: a value
+passed with --password is visible in the process table for the lifetime of the
+command and is written to your shell history. with neither flag, an interactive
+terminal is prompted without echo.`,
+	Example: `  # read the password from a pipe (preferred)
+  echo "$REGISTRY_TOKEN" | runpodctl registry create --name ghcr --username me --password-stdin
+
+  # read it from a file without exposing it to the process table
+  runpodctl registry create --name ghcr --username me --password-stdin < token.txt
+
+  # prompt for it, without echo
+  runpodctl registry create --name ghcr --username me`,
+	Args: cobra.NoArgs,
+	RunE: runCreate,
 }
 
 var (
-	createName     string
-	createUsername string
-	createPassword string
+	createName          string
+	createUsername      string
+	createPassword      string
+	createPasswordStdin bool
 )
 
 func init() {
 	createCmd.Flags().StringVar(&createName, "name", "", "registry auth name (required)")
 	createCmd.Flags().StringVar(&createUsername, "username", "", "registry username (required)")
-	createCmd.Flags().StringVar(&createPassword, "password", "", "registry password (required)")
+	createCmd.Flags().StringVar(&createPassword, "password", "", "registry password; insecure, prefer --password-stdin")
+	createCmd.Flags().BoolVar(&createPasswordStdin, "password-stdin", false, "read the registry password from stdin")
 
 	createCmd.MarkFlagRequired("name")     //nolint:errcheck
 	createCmd.MarkFlagRequired("username") //nolint:errcheck
-	createCmd.MarkFlagRequired("password") //nolint:errcheck
+	// --password is deliberately not marked required: cobra enforces required flags
+	// before RunE, which would reject the --password-stdin and prompt paths before
+	// they can supply the value. resolvePassword enforces it instead.
+	createCmd.MarkFlagsMutuallyExclusive("password", "password-stdin")
+}
+
+// promptPassword is a package variable so tests can exercise the prompt branch
+// without a controlling terminal.
+var promptPassword = func(stderr io.Writer) (string, error) {
+	fmt.Fprint(stderr, "registry password: ")
+	secret, err := term.ReadPassword(int(os.Stdin.Fd()))
+	// ReadPassword swallows the user's newline, so the next line of output would
+	// otherwise start on the prompt line.
+	fmt.Fprintln(stderr)
+	if err != nil {
+		return "", fmt.Errorf("failed to read the password from the terminal: %w", err)
+	}
+	return string(secret), nil
+}
+
+// stdinIsTerminal reports whether stdin is a terminal we can prompt on, as
+// opposed to a pipe or a redirected file.
+var stdinIsTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
+
+// resolvePassword picks the registry password out of the three supported
+// sources. It takes the reader and writer rather than touching os.Stdin/Stderr
+// directly so the whole matrix is testable without a tty.
+//
+// A password on the command line is not refused, only warned about: scripts
+// already pass it that way and breaking them is not this change's job.
+func resolvePassword(stdin io.Reader, stderr io.Writer, flagValue string, fromStdin bool) (string, error) {
+	switch {
+	case fromStdin:
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", fmt.Errorf("failed to read the password from stdin: %w", err)
+		}
+		// strip only the trailing line ending a pipe or heredoc adds. leading and
+		// inner whitespace can be part of the credential and must survive.
+		secret := strings.TrimSuffix(strings.TrimSuffix(string(data), "\n"), "\r")
+		if secret == "" {
+			return "", clierr.Usagef("the password read from stdin is empty")
+		}
+		// a token never spans lines, so this is a redirected file with extra
+		// content rather than a credential. the api would reject it with a less
+		// obvious error.
+		if strings.ContainsAny(secret, "\r\n") {
+			return "", clierr.Usagef("the password read from stdin spans multiple lines")
+		}
+		return secret, nil
+
+	case flagValue != "":
+		fmt.Fprintln(stderr, "warning: --password is insecure; it is visible in the process table and your shell history. use --password-stdin instead.")
+		return flagValue, nil
+
+	case stdinIsTerminal():
+		secret, err := promptPassword(stderr)
+		if err != nil {
+			return "", err
+		}
+		if secret == "" {
+			return "", clierr.Usagef("no password entered")
+		}
+		return secret, nil
+
+	default:
+		// non-interactive with no password source is a scripting mistake, and
+		// silently prompting into a pipe would hang instead of reporting it.
+		return "", clierr.Usagef("a password is required; pass --password-stdin to read it from stdin, or --password")
+	}
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
+	password, err := resolvePassword(cmd.InOrStdin(), cmd.ErrOrStderr(), createPassword, createPasswordStdin)
+	if err != nil {
+		return err
+	}
+
 	client, err := api.NewClient()
 	if err != nil {
 		return err
@@ -42,7 +136,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	req := &api.ContainerRegistryAuthCreateRequest{
 		Name:     createName,
 		Username: createUsername,
-		Password: createPassword,
+		Password: password,
 	}
 
 	auth, err := client.CreateContainerRegistryAuth(req)

--- a/cmd/registry/create.go
+++ b/cmd/registry/create.go
@@ -19,11 +19,10 @@ var createCmd = &cobra.Command{
 	Short: "create a new registry auth",
 	Long: `create a new container registry authentication
 
-the password is a long-lived credential, so prefer --password-stdin: a value
-passed with --password is visible in the process table for the lifetime of the
-command and is written to your shell history. with neither flag, an interactive
-terminal is prompted without echo.`,
-	Example: `  # read the password from a pipe (preferred)
+the password can come from --password, from stdin with --password-stdin, or from
+an interactive prompt when neither flag is given. --password-stdin keeps the
+credential out of the process table and your shell history.`,
+	Example: `  # read the password from a pipe
   echo "$REGISTRY_TOKEN" | runpodctl registry create --name ghcr --username me --password-stdin
 
   # read it from a file without exposing it to the process table
@@ -45,7 +44,7 @@ var (
 func init() {
 	createCmd.Flags().StringVar(&createName, "name", "", "registry auth name (required)")
 	createCmd.Flags().StringVar(&createUsername, "username", "", "registry username (required)")
-	createCmd.Flags().StringVar(&createPassword, "password", "", "registry password; insecure, prefer --password-stdin")
+	createCmd.Flags().StringVar(&createPassword, "password", "", "registry password; see also --password-stdin")
 	createCmd.Flags().BoolVar(&createPasswordStdin, "password-stdin", false, "read the registry password from stdin")
 
 	createCmd.MarkFlagRequired("name")     //nolint:errcheck
@@ -78,8 +77,8 @@ var stdinIsTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
 // sources. It takes the reader and writer rather than touching os.Stdin/Stderr
 // directly so the whole matrix is testable without a tty.
 //
-// A password on the command line is not refused, only warned about: scripts
-// already pass it that way and breaking them is not this change's job.
+// --password stays a first-class choice: it is the caller's call whether argv
+// exposure matters for their environment, and scripts already pass it that way.
 func resolvePassword(stdin io.Reader, stderr io.Writer, flagValue string, fromStdin bool) (string, error) {
 	switch {
 	case fromStdin:
@@ -102,7 +101,6 @@ func resolvePassword(stdin io.Reader, stderr io.Writer, flagValue string, fromSt
 		return secret, nil
 
 	case flagValue != "":
-		fmt.Fprintln(stderr, "warning: --password is insecure; it is visible in the process table and your shell history. use --password-stdin instead.")
 		return flagValue, nil
 
 	case stdinIsTerminal():

--- a/cmd/registry/create_password_test.go
+++ b/cmd/registry/create_password_test.go
@@ -34,6 +34,7 @@ func TestSignalExitCode(t *testing.T) {
 	}{
 		{name: "interrupt", sig: os.Interrupt, want: 130},
 		{name: "terminate", sig: syscall.SIGTERM, want: 143},
+		{name: "quit", sig: syscall.SIGQUIT, want: 131},
 	}
 
 	for _, tt := range tests {

--- a/cmd/registry/create_password_test.go
+++ b/cmd/registry/create_password_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"os"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -22,6 +24,25 @@ func stubTerminal(t *testing.T, isTTY bool, secret string, promptErr error) *boo
 		return secret, promptErr
 	}
 	return &prompted
+}
+
+func TestSignalExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  os.Signal
+		want int
+	}{
+		{name: "interrupt", sig: os.Interrupt, want: 130},
+		{name: "terminate", sig: syscall.SIGTERM, want: 143},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := signalExitCode(tt.sig); got != tt.want {
+				t.Errorf("signalExitCode(%v) = %d, want %d", tt.sig, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestResolvePasswordFromStdin(t *testing.T) {

--- a/cmd/registry/create_password_test.go
+++ b/cmd/registry/create_password_test.go
@@ -60,6 +60,23 @@ func TestResolvePasswordFromStdin(t *testing.T) {
 	}
 }
 
+// a gcr.io / artifact registry credential is an entire service-account json key
+// passed as the password (username _json_key), the same shape docker login takes
+// on stdin. it is multi-line, the api accepts it, and an earlier revision of this
+// resolver rejected it -- so it stays pinned.
+func TestResolvePasswordKeepsAMultiLineCredential(t *testing.T) {
+	stubTerminal(t, false, "", nil)
+	key := "{\n  \"type\": \"service_account\",\n  \"private_key\": \"-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----\\n\"\n}"
+
+	got, err := resolvePassword(strings.NewReader(key+"\n"), io.Discard, "", true)
+	if err != nil {
+		t.Fatalf("a multi-line credential must be accepted: %v", err)
+	}
+	if got != key {
+		t.Errorf("password = %q, want the key back with only the trailing newline stripped", got)
+	}
+}
+
 func TestResolvePasswordRejectsBadStdin(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -68,8 +85,6 @@ func TestResolvePasswordRejectsBadStdin(t *testing.T) {
 	}{
 		{name: "empty stdin", stdin: "", wantMsg: "empty"},
 		{name: "only a newline", stdin: "\n", wantMsg: "empty"},
-		// a redirected file with extra content, not a credential.
-		{name: "multiple lines", stdin: "s3cret\nextra\n", wantMsg: "multiple lines"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/registry/create_password_test.go
+++ b/cmd/registry/create_password_test.go
@@ -107,7 +107,7 @@ func TestResolvePasswordFromStdinReportsReadFailure(t *testing.T) {
 	}
 }
 
-func TestResolvePasswordFromFlagWarns(t *testing.T) {
+func TestResolvePasswordFromFlag(t *testing.T) {
 	stubTerminal(t, false, "", nil)
 	var stderr bytes.Buffer
 
@@ -118,23 +118,10 @@ func TestResolvePasswordFromFlagWarns(t *testing.T) {
 	if got != "s3cret" {
 		t.Errorf("password = %q, want s3cret", got)
 	}
-
-	// the warning is the whole point of keeping --password working, so assert it
-	// lands and names the safe alternative.
-	warning := stderr.String()
-	if !strings.Contains(warning, "--password-stdin") {
-		t.Errorf("warning must point at --password-stdin, got %q", warning)
-	}
-	if !strings.Contains(warning, "warning:") {
-		t.Errorf("warning must be marked as one, got %q", warning)
-	}
-	// AGENTS.md: all text output is lowercase.
-	if warning != strings.ToLower(warning) {
-		t.Errorf("warning must be lowercase, got %q", warning)
-	}
-	// the secret itself must never be echoed back.
-	if strings.Contains(warning, "s3cret") {
-		t.Error("the warning must not repeat the password")
+	// --password is a supported choice, not a mistake: it must not nag, and it
+	// must never echo the credential it was handed.
+	if stderr.Len() != 0 {
+		t.Errorf("expected no output on the --password path, got %q", stderr.String())
 	}
 }
 

--- a/cmd/registry/create_password_test.go
+++ b/cmd/registry/create_password_test.go
@@ -1,0 +1,225 @@
+package registry
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// stubTerminal forces the prompt branch on and off regardless of how the test
+// binary's stdin is wired, and restores the real detector afterwards.
+func stubTerminal(t *testing.T, isTTY bool, secret string, promptErr error) *bool {
+	t.Helper()
+	origTTY, origPrompt := stdinIsTerminal, promptPassword
+	t.Cleanup(func() { stdinIsTerminal, promptPassword = origTTY, origPrompt })
+
+	prompted := false
+	stdinIsTerminal = func() bool { return isTTY }
+	promptPassword = func(io.Writer) (string, error) {
+		prompted = true
+		return secret, promptErr
+	}
+	return &prompted
+}
+
+func TestResolvePasswordFromStdin(t *testing.T) {
+	tests := []struct {
+		name  string
+		stdin string
+		want  string
+	}{
+		{name: "plain value", stdin: "s3cret", want: "s3cret"},
+		{name: "trailing newline from a pipe is stripped", stdin: "s3cret\n", want: "s3cret"},
+		{name: "trailing crlf is stripped", stdin: "s3cret\r\n", want: "s3cret"},
+		// a credential may legitimately contain these, so they must survive intact.
+		{name: "inner whitespace survives", stdin: "s3 cret\n", want: "s3 cret"},
+		{name: "leading whitespace survives", stdin: " s3cret\n", want: " s3cret"},
+		{name: "trailing space before the newline survives", stdin: "s3cret \n", want: "s3cret "},
+		{name: "a token that looks like a flag is not parsed", stdin: "--not-a-flag\n", want: "--not-a-flag"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubTerminal(t, false, "", nil)
+			var stderr bytes.Buffer
+
+			got, err := resolvePassword(strings.NewReader(tt.stdin), &stderr, "", true)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("password = %q, want %q", got, tt.want)
+			}
+			// the secure path must not nag.
+			if stderr.Len() != 0 {
+				t.Errorf("expected no warning on the stdin path, got %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestResolvePasswordRejectsBadStdin(t *testing.T) {
+	tests := []struct {
+		name    string
+		stdin   string
+		wantMsg string
+	}{
+		{name: "empty stdin", stdin: "", wantMsg: "empty"},
+		{name: "only a newline", stdin: "\n", wantMsg: "empty"},
+		// a redirected file with extra content, not a credential.
+		{name: "multiple lines", stdin: "s3cret\nextra\n", wantMsg: "multiple lines"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubTerminal(t, false, "", nil)
+
+			_, err := resolvePassword(strings.NewReader(tt.stdin), io.Discard, "", true)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("error = %q, want it to mention %q", err.Error(), tt.wantMsg)
+			}
+			assertUsageError(t, err)
+		})
+	}
+}
+
+func TestResolvePasswordFromStdinReportsReadFailure(t *testing.T) {
+	stubTerminal(t, false, "", nil)
+	sentinel := errors.New("pipe broke")
+
+	_, err := resolvePassword(errReader{sentinel}, io.Discard, "", true)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	// an unreadable pipe is an environment failure, not a caller mistake, so it
+	// must not be coded as a usage error.
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected the cause to stay wrapped, got %v", err)
+	}
+	var coder interface{ ErrorCode() string }
+	if errors.As(err, &coder) {
+		t.Errorf("a broken pipe must not be a %s", coder.ErrorCode())
+	}
+}
+
+func TestResolvePasswordFromFlagWarns(t *testing.T) {
+	stubTerminal(t, false, "", nil)
+	var stderr bytes.Buffer
+
+	got, err := resolvePassword(strings.NewReader(""), &stderr, "s3cret", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "s3cret" {
+		t.Errorf("password = %q, want s3cret", got)
+	}
+
+	// the warning is the whole point of keeping --password working, so assert it
+	// lands and names the safe alternative.
+	warning := stderr.String()
+	if !strings.Contains(warning, "--password-stdin") {
+		t.Errorf("warning must point at --password-stdin, got %q", warning)
+	}
+	if !strings.Contains(warning, "warning:") {
+		t.Errorf("warning must be marked as one, got %q", warning)
+	}
+	// AGENTS.md: all text output is lowercase.
+	if warning != strings.ToLower(warning) {
+		t.Errorf("warning must be lowercase, got %q", warning)
+	}
+	// the secret itself must never be echoed back.
+	if strings.Contains(warning, "s3cret") {
+		t.Error("the warning must not repeat the password")
+	}
+}
+
+// --password wins over an unread stdin: cobra rejects the two flags together, so
+// this only fixes the precedence for a caller that pipes without asking for it.
+func TestResolvePasswordFlagDoesNotConsumeStdin(t *testing.T) {
+	stubTerminal(t, false, "", nil)
+	stdin := strings.NewReader("from-stdin\n")
+
+	got, err := resolvePassword(stdin, io.Discard, "from-flag", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "from-flag" {
+		t.Errorf("password = %q, want from-flag", got)
+	}
+	if left, _ := io.ReadAll(stdin); string(left) != "from-stdin\n" {
+		t.Errorf("stdin must be left untouched, %q was consumed", "from-stdin\n")
+	}
+}
+
+func TestResolvePasswordPromptsOnATerminal(t *testing.T) {
+	prompted := stubTerminal(t, true, "typed-secret", nil)
+
+	got, err := resolvePassword(strings.NewReader(""), io.Discard, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !*prompted {
+		t.Error("expected the terminal to be prompted")
+	}
+	if got != "typed-secret" {
+		t.Errorf("password = %q, want typed-secret", got)
+	}
+}
+
+func TestResolvePasswordRejectsAnEmptyPrompt(t *testing.T) {
+	stubTerminal(t, true, "", nil)
+
+	_, err := resolvePassword(strings.NewReader(""), io.Discard, "", false)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	assertUsageError(t, err)
+}
+
+func TestResolvePasswordPropagatesPromptFailure(t *testing.T) {
+	sentinel := errors.New("no tty after all")
+	stubTerminal(t, true, "", sentinel)
+
+	_, err := resolvePassword(strings.NewReader(""), io.Discard, "", false)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected the prompt failure to propagate, got %v", err)
+	}
+}
+
+// the regression that matters for scripts: no password source and no terminal
+// must fail fast rather than block forever on a read that will never arrive.
+func TestResolvePasswordFailsWithoutATerminalOrASource(t *testing.T) {
+	prompted := stubTerminal(t, false, "unused", nil)
+
+	_, err := resolvePassword(strings.NewReader(""), io.Discard, "", false)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if *prompted {
+		t.Error("must not prompt when stdin is not a terminal")
+	}
+	if !strings.Contains(err.Error(), "--password-stdin") {
+		t.Errorf("error must name the safe flag, got %q", err.Error())
+	}
+	assertUsageError(t, err)
+}
+
+func assertUsageError(t *testing.T, err error) {
+	t.Helper()
+	var coder interface{ ErrorCode() string }
+	if !errors.As(err, &coder) {
+		t.Fatalf("expected a coded error, got %v", err)
+	}
+	if coder.ErrorCode() != "usage_error" {
+		t.Errorf("code = %q, want usage_error", coder.ErrorCode())
+	}
+}
+
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }

--- a/cmd/registry/registry_test.go
+++ b/cmd/registry/registry_test.go
@@ -1,7 +1,10 @@
 package registry
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestRegistryCmd_Structure(t *testing.T) {
@@ -54,5 +57,30 @@ func TestCreateCmd_RequiredFlags(t *testing.T) {
 	}
 	if flags.Lookup("password") == nil {
 		t.Error("expected --password flag")
+	}
+	if flags.Lookup("password-stdin") == nil {
+		t.Error("expected --password-stdin flag")
+	}
+
+	// --name and --username are enforced by cobra; --password deliberately is not,
+	// because cobra checks required flags before RunE and would reject the
+	// --password-stdin and prompt paths before they can supply a value.
+	for flag, wantRequired := range map[string]bool{"name": true, "username": true, "password": false} {
+		required := flags.Lookup(flag).Annotations[cobra.BashCompOneRequiredFlag] != nil
+		if required != wantRequired {
+			t.Errorf("--%s required = %v, want %v", flag, required, wantRequired)
+		}
+	}
+}
+
+// passing both would silently pick one; cobra must reject the combination.
+func TestCreateCmd_PasswordFlagsAreMutuallyExclusive(t *testing.T) {
+	cmd := createCmd
+	groups := cmd.Flags().Lookup("password").Annotations["cobra_annotation_mutually_exclusive"]
+	if len(groups) == 0 {
+		t.Fatal("expected --password to be in a mutually exclusive group")
+	}
+	if !strings.Contains(groups[0], "password-stdin") {
+		t.Errorf("expected the group to include password-stdin, got %v", groups)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -255,6 +255,10 @@ var usageErrorPrefixes = []string{
 	// through SetFlagErrorFunc and has to be matched here (20 MarkFlagRequired
 	// sites, e.g. `template create` with no --name/--image).
 	"required flag(s)",
+	// ValidateFlagGroups is in the same post-parse position as
+	// ValidateRequiredFlags above, so MarkFlagsMutuallyExclusive violations
+	// (registry create's --password / --password-stdin) also land here.
+	"if any flags in the group",
 }
 
 // asUsageError reports whether err represents a usage error, returning a

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -318,6 +318,8 @@ func TestAsUsageError(t *testing.T) {
 		`invalid argument "x" for "--count"`,
 		// ValidateRequiredFlags bypasses SetFlagErrorFunc, so it must match here.
 		`required flag(s) "image", "name" not set`,
+		// ValidateFlagGroups, same position: registry create's --password pair.
+		"if any flags in the group [password password-stdin] are set none of the others can be; [password password-stdin] were all set",
 	}
 	for _, msg := range usageCases {
 		if _, ok := asUsageError(root, errors.New(msg)); !ok {

--- a/docs/runpodctl_registry_create.md
+++ b/docs/runpodctl_registry_create.md
@@ -6,8 +6,25 @@ create a new registry auth
 
 create a new container registry authentication
 
+the password can come from --password, from stdin with --password-stdin, or from
+an interactive prompt when neither flag is given. --password-stdin keeps the
+credential out of the process table and your shell history.
+
 ```
 runpodctl registry create [flags]
+```
+
+### Examples
+
+```
+  # read the password from a pipe
+  echo "$REGISTRY_TOKEN" | runpodctl registry create --name ghcr --username me --password-stdin
+
+  # read it from a file without exposing it to the process table
+  runpodctl registry create --name ghcr --username me --password-stdin < token.txt
+
+  # prompt for it, without echo
+  runpodctl registry create --name ghcr --username me
 ```
 
 ### Options
@@ -15,7 +32,8 @@ runpodctl registry create [flags]
 ```
   -h, --help              help for create
       --name string       registry auth name (required)
-      --password string   registry password (required)
+      --password string   registry password; see also --password-stdin
+      --password-stdin    read the registry password from stdin
       --username string   registry username (required)
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	golang.org/x/crypto v0.53.0
 	golang.org/x/crypto/x509roots/fallback v0.0.0-20260213171211-a408498e5541
 	golang.org/x/mod v0.37.0
+	golang.org/x/term v0.44.0
 	golang.org/x/time v0.5.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -58,7 +59,6 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )


### PR DESCRIPTION
Closes #327

## Context

`registry create` stores a container-registry credential so Runpod can pull private images. It needs a username and a password or access token:

```console
$ runpodctl registry create --name ghcr --username me --password <secret>
```

## The issue

`--password` was the only way to supply the secret, and cobra marked it **required** — so there was no way to run the command without putting a long-lived credential in `argv`, where it is readable from the process table and written to shell history. No `--password-stdin`, no file, no prompt.

The reporter did not use the command at all: they created the registry auth in the console and read back only the id with `registry list`, specifically to avoid the flag. So the CLI was unusable for the one workflow it exists to serve, by anyone who treats registry tokens as secrets.

## The fix

- **`--password-stdin`**, matching `docker login`.
- **A no-echo prompt** when stdin is a terminal and neither flag is given.
- **`--password` is unchanged** and stays a first-class option — no warning, no deprecation. Whether argv exposure matters is the caller's call.
- The two password flags are mutually exclusive.

```console
$ echo "$TOKEN" | runpodctl registry create --name ghcr --username me --password-stdin
$ runpodctl registry create --name ghcr --username me --password-stdin < token.txt
$ runpodctl registry create --name ghcr --username me      # prompts, no echo
```

## Two things I'd like a second opinion on

**1. I removed `MarkFlagRequired("password")`.** Cobra enforces required flags *before* `RunE`, so leaving it would reject the stdin and prompt paths before they could supply a value — the new features cannot work with that line present. The guarantee therefore moves from the framework into `resolvePassword`, which is hand-written and so can be wrong in a way the framework could not. I traced every branch and `registry_test.go` now pins the required/not-required split per flag, but "I checked my own logic" is the claim worth verifying rather than accepting.

**2. I added four lines to `cmd/root.go`, outside the registry package.** This is the repo's first `MarkFlagsMutuallyExclusive` site, so cobra's `ValidateFlagGroups` message reached the central error classifier unrecognised and reported `cli_error` ("something broke") instead of `usage_error` ("you used it wrong"). Adding it to `usageErrorPrefixes` fixes the label.

Two caveats. That file classifies errors for the whole CLI, so it is the only part of this PR that can affect commands I did not touch. And it works by matching cobra's English message text — five entries already do this, with a comment warning to re-check them on cobra upgrades, but this adds a sixth hostage to that fragility. Additive and narrow, but worth agreeing to rather than inheriting.

`golang.org/x/term` moves from indirect to direct. No new dependency.

## Two defects I found and fixed in self-review

**Multi-line stdin was rejected.** I had guarded on the assumption that a credential never spans lines. A gcr.io / Artifact Registry credential is an entire service-account json key passed as the password with username `_json_key` — the same shape `docker login --password-stdin` takes. I confirmed against the live api that it accepts a multi-line password, so the guard rejected valid input and broke the exact workflow `--password-stdin` exists for. Removed, with a regression test.

**Ctrl-C at the prompt left the terminal broken.** `term.ReadPassword` disables echo and restores it from a deferred ioctl, which SIGINT's default disposition never reaches — the process died with echo still off, leaving the caller's shell typing blind until `stty sane`. Reproduced on a pty (`ECHO` still false after SIGINT). The prompt now restores saved terminal state from a signal handler and exits 130. Re-verified on a pty: echo returns to on, exit code is 130, normal path unaffected.

## Testing

10 new tests in `cmd/registry/create_password_test.go` (13 top-level in the package, 9 subtests). `resolvePassword` takes an `io.Reader`/`io.Writer`, and the tty detector and prompt are package vars, so the whole matrix runs without a terminal: a trailing `\n`/`\r\n` is stripped while leading, inner and pre-newline whitespace survive; empty stdin rejected while a multi-line credential is preserved; a broken pipe stays uncoded (environment failure, not usage); `--password` asserted to print nothing and leave stdin unconsumed; no-source-no-tty fails fast rather than blocking on a read that never arrives.

<details>
<summary>Live e2e against the production api, resources cleaned up</summary>

Per AGENTS.md, built the binary and ran every path against the live api.

| path | result |
|---|---|
| `--password-stdin` via pipe | created ok |
| `--password` flag | created ok, stdout parseable json, stderr empty |
| `--password-stdin < file` | created ok |
| interactive prompt on a real pty | created ok, prompt shown, typed secret absent from the pty transcript (echo genuinely off) |
| multi-line `_json_key` json on stdin | created ok — the regression the self-review fix was for |

Error paths return before any api call, because `resolvePassword` runs first. Each returns `usage_error` and exits 1:

- both `--password` and `--password-stdin` together
- empty stdin with `--password-stdin`
- no password source with stdin not a terminal

`--name`/`--username` remain required. Multi-line stdin is **accepted**, not an error.

Every auth created was deleted afterwards, and `registry list` confirmed clean.

</details>

---

## Related PRs

Two independent groups. Nothing in one blocks anything in the other.

### Group A — the Windows install command (runpod/runpodctl#311)

One broken command that had been copy-pasted into three repos. Each PR fixes its own copy; **any order, no dependencies.**

| PR | Repo | Change |
|---|---|---|
| runpod/runpodctl#328 | runpodctl | `README.md` — fix the command, and install to `PATH` |
| runpod/docs#805 | docs | `runpodctl/overview.mdx` — same fix on docs.runpod.io |
| runpod/runpod-plugins-official#49 | plugins | delete `reference/install.md`, the third copy |

### Group B — secure registry passwords (runpod/runpodctl#327)

**Order matters.** #51 documents a flag that does not exist on `main` until #329 merges, so it stays draft until then.

| # | PR | Repo | Change |
|---|---|---|---|
| 1 | runpod/runpodctl#329 ← **this PR** | runpodctl | `--password-stdin`, no-echo prompt, mutually exclusive flags |
| 2 | runpod/runpod-plugins-official#51 | plugins | skill guidance + regression eval (**draft** until #329 lands) |

The only thing the two groups share is that both touched the runpodctl skill, which is what prompted Group A's deletion: the skill had been keeping its own copy of install instructions the runpodctl README already owned.