### PR TITLE
fix(pod): remove --stop-after and --terminate-after

### DIFF
--- a/cmd/pod/create.go
+++ b/cmd/pod/create.go
@@ -68,8 +68,6 @@ var (
 	createDockerArgs        string
 	createRegistryAuthID    string
 	createCountryCode       string
-	createStopAfter         string
-	createTerminateAfter    string
 	createCompliance        string
 	createWait              bool
 	createWaitTimeout       string
@@ -97,8 +95,6 @@ func init() {
 	createCmd.Flags().StringVar(&createDockerArgs, "docker-args", "", "docker cmd arguments")
 	createCmd.Flags().StringVar(&createRegistryAuthID, "registry-auth-id", "", "container registry auth id (from 'runpodctl registry list')")
 	createCmd.Flags().StringVar(&createCountryCode, "country-code", "", "limit pod to a specific country (e.g., US, DE)")
-	createCmd.Flags().StringVar(&createStopAfter, "stop-after", "", "auto-stop datetime (e.g., 2026-04-15T00:00:00Z)")
-	createCmd.Flags().StringVar(&createTerminateAfter, "terminate-after", "", "auto-terminate datetime (e.g., 2026-04-15T00:00:00Z)")
 	createCmd.Flags().StringVar(&createCompliance, "compliance", "", "comma-separated compliance requirements (e.g., HIPAA,SOC_2_TYPE_2)")
 	createCmd.Flags().BoolVar(&createWait, "wait", false, "block until ssh is reachable (tcp connect to the pod's public port 22 answers with an ssh banner; no key or handshake needed), then print the pod as 'pod get' does. needs a publicly mapped port 22, so community cloud also needs --public-ip")
 	createCmd.Flags().StringVar(&createWaitTimeout, "wait-timeout", defaultWaitTimeout, "max time to wait with --wait, e.g. 90s, 10m, 1h; on timeout the pod is kept and the error carries its id")
@@ -446,14 +442,6 @@ func createPodGraphQL(gpuTypeID, cloudType string, supportPublicIP bool) (map[st
 
 	if createCountryCode != "" {
 		req.CountryCode = createCountryCode
-	}
-
-	if createStopAfter != "" {
-		req.StopAfter = createStopAfter
-	}
-
-	if createTerminateAfter != "" {
-		req.TerminateAfter = createTerminateAfter
 	}
 
 	if createCompliance != "" {

--- a/docs/runpodctl_pod_create.md
+++ b/docs/runpodctl_pod_create.md
@@ -52,9 +52,7 @@ runpodctl pod create [flags]
       --public-ip                  require public ip (community cloud only)
       --registry-auth-id string    container registry auth id (from 'runpodctl registry list')
       --ssh                        enable ssh on the pod (default true)
-      --stop-after string          auto-stop datetime (e.g., 2026-04-15T00:00:00Z)
       --template-id string         template id (use 'runpodctl template search' to find templates)
-      --terminate-after string     auto-terminate datetime (e.g., 2026-04-15T00:00:00Z)
       --volume-in-gb int           volume size in gb
       --volume-mount-path string   volume mount path (default "/workspace")
       --wait                       block until ssh is reachable (tcp connect to the pod's public port 22 answers with an ssh banner; no key or handshake needed), then print the pod as 'pod get' does. needs a publicly mapped port 22, so community cloud also needs --public-ip

--- a/internal/api/graphql.go
+++ b/internal/api/graphql.go
@@ -324,8 +324,6 @@ type CreatePodGQLInput struct {
 	DockerArgs              string       `json:"dockerArgs,omitempty"`
 	ContainerRegistryAuthId string       `json:"containerRegistryAuthId,omitempty"`
 	CountryCode             string       `json:"countryCode,omitempty"`
-	StopAfter               string       `json:"stopAfter,omitempty"`
-	TerminateAfter          string       `json:"terminateAfter,omitempty"`
 	Compliance              []string     `json:"compliance,omitempty"`
 }
 


### PR DESCRIPTION
`--stop-after` and `--terminate-after` never worked. Both are removed.

Part of CON-1258, which stays open: this removes the broken surface, it does not fix the feature. runpod/RunPod#5718 is the backend fix that makes the deadline actually fire, and runpodctl#331 restores the flags with validation once it lands.

## Why

The flags were forwarded to `podFindAndDeployOnDemand` as `stopAfter` / `terminateAfter`. The API accepts both as valid input and then does not act on them: the pod keeps running, and billing, past the deadline.

The value is also write-only. It is not readable on the `Pod` type and does not exist in REST v2 at all, so the CLI cannot confirm the timer landed, and cannot detect afterwards that it did not fire.

Three further problems, all moot once the flag is gone:

- CPU pods dropped it silently — they are created over REST v2, which has no scheduling field.
- Past timestamps were accepted; the deadline simply never arrived.
- The documented duration form (`1h`, `24h`, `7d`) was rejected by the GraphQL `DateTime` scalar, leaking the raw scalar error. Only RFC 3339 was ever sent successfully.

Nothing a client can do makes the timer fire, and a flag that silently costs money is worse than no flag.

## What changed

Both flags are deleted. Passing one is a usage error:

```
$ runpodctl pod create --image ubuntu:22.04 --stop-after 2h
{"error":"unknown flag: --stop-after","code":"usage_error"}
```

They no longer appear in `--help` or the generated docs, and `StopAfter` / `TerminateAfter` are dropped from `CreatePodGQLInput`. `internal/duration` is untouched — `duration.Parse` still backs `--since` and `--wait-timeout`.

## Release notes

**Breaking.** `runpodctl pod create --stop-after` and `--terminate-after` are removed. Scripts passing either now fail with `unknown flag` and a non-zero exit instead of creating a pod on a timer that never fired. There is no replacement until the backend enforces the deadline; until then, stop or terminate the pod explicitly.

<details>
<summary>Evidence</summary>

Two GPU pods created against production with `stopAfter` roughly four minutes out. Both stayed `RUNNING` past the deadline, with no state change and no error. Deleted manually afterwards.

| Pod | stopAfter | Last observation | desiredStatus |
|---|---|---|---|
| `mqb8yey2sq8qka` | 16:45:46Z | 16:49:34Z | `RUNNING` |
| `bdwcl5lzqwqny0` | 16:48:35Z | 16:49:34Z | `RUNNING` |

`go build ./...` and `go test ./...` green.
</details>