### PR TITLE
docs: configure api key with doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ pixi global install runpodctl
 
 ```bash
 # configure api key
-runpodctl config --apiKey=your_api_key
+runpodctl doctor
 
 # list all pods
 runpodctl pod list


### PR DESCRIPTION
Related to #231

## Context

The README quickstart tells users to run:

```bash
runpodctl config --apiKey=your_api_key
```

That command is deprecated (v2.0.0) and prints a warning now, but `README.md` was never updated. As a new user, I was surprised to run the recommended command and see a deprecation warning.

## The fix

Swap the README instruction to `runpodctl doctor`.


## Verification

Docs only change, no code touched.
