### PR TITLE
STO-446: feat(model): add --delete-my-model-files-after-upload

### DIFF
--- a/cmd/model/addModelDeleteAfterUpload_test.go
+++ b/cmd/model/addModelDeleteAfterUpload_test.go
@@ -1,0 +1,272 @@
+package model
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/runpod/runpodctl/api"
+)
+
+// STO-446: runpodctl model add --delete-my-model-files-after-upload deletes
+// only the local files that were part of THIS run's upload, and only after
+// the model version hash is confirmed server-side. It must never delete
+// anything before that confirmation, and must fail loudly (non-zero exit,
+// no silent partial success) if confirmation or deletion does not fully
+// succeed.
+
+func TestValidateAddModelFlagsRequiresModelPathForDeleteAfterUpload(t *testing.T) {
+	resetAddModelGlobals(t)
+
+	addModelDeleteAfterUpload = true
+	addModelWaitForHash = true // satisfied, so only the model-path gap should trip
+
+	err := validateAddModelFlags()
+	if err == nil || !strings.Contains(err.Error(), "--delete-my-model-files-after-upload requires --model-path") {
+		t.Fatalf("expected model-path requirement error, got %v", err)
+	}
+}
+
+func TestValidateAddModelFlagsRequiresWaitForHashForDeleteAfterUpload(t *testing.T) {
+	resetAddModelGlobals(t)
+
+	addModelDeleteAfterUpload = true
+	addModelDirectoryPath = "/tmp/some-model-dir" // satisfied, so only the wait-for-hash gap should trip
+
+	err := validateAddModelFlags()
+	if err == nil || !strings.Contains(err.Error(), "--delete-my-model-files-after-upload requires --wait-for-hash") {
+		t.Fatalf("expected wait-for-hash requirement error, got %v", err)
+	}
+}
+
+func TestValidateAddModelFlagsAllowsDeleteAfterUploadWithBothRequirements(t *testing.T) {
+	resetAddModelGlobals(t)
+
+	addModelDeleteAfterUpload = true
+	addModelDirectoryPath = "/tmp/some-model-dir"
+	addModelWaitForHash = true
+
+	if err := validateAddModelFlags(); err != nil {
+		t.Fatalf("expected no error once both requirements are satisfied, got %v", err)
+	}
+}
+
+// stubAddModelUploadSeams wires every seam runAddModel needs for a
+// model-path + wait-for-hash upload to succeed, returning the confirmed
+// hash immediately (no polling). Tests override individual seams after
+// calling this to exercise failure paths.
+func stubAddModelUploadSeams(t *testing.T) {
+	t.Helper()
+
+	oldAddModelToRepo := addModelToRepo
+	oldCreateModelRepoUpload := createModelRepoUpload
+	oldCompleteModelUploadFile := completeModelUploadFile
+	oldCompleteModelRepoUpload := completeModelRepoUpload
+	oldGetModelsForAdd := getModelsForAdd
+	t.Cleanup(func() {
+		addModelToRepo = oldAddModelToRepo
+		createModelRepoUpload = oldCreateModelRepoUpload
+		completeModelUploadFile = oldCompleteModelUploadFile
+		completeModelRepoUpload = oldCompleteModelRepoUpload
+		getModelsForAdd = oldGetModelsForAdd
+	})
+
+	addModelToRepo = func(input *api.AddModelToRepoInput) (*api.Model, error) {
+		return &api.Model{ID: "model-id", Owner: "user-id", Name: "test-model", Provider: "huggingface"}, nil
+	}
+	createModelRepoUpload = func(input *api.CreateModelRepoUploadInput) (*api.ModelRepoMutationResult, error) {
+		return &api.ModelRepoMutationResult{
+			Success: true,
+			Model:   &api.Model{ID: "model-id", Owner: "user-id", Name: "test-model", Provider: "LOCAL"},
+			Version: &api.ModelVersion{UUID: "version-uuid"},
+			Upload:  &api.ModelRepoUpload{SessionID: "session-" + input.FileName, Key: "key-" + input.FileName},
+		}, nil
+	}
+	completeModelUploadFile = func(upload *api.ModelRepoUpload, artifactPath string, progress modelUploadProgress) error {
+		return nil
+	}
+	completeModelRepoUpload = func(sessionID string) (*api.CompleteModelRepoUploadResult, error) {
+		return &api.CompleteModelRepoUploadResult{SessionID: sessionID, Status: "completed"}, nil
+	}
+	getModelsForAdd = func(input *api.GetModelsInput) ([]*api.Model, error) {
+		return []*api.Model{{
+			ID:       "model-id",
+			Owner:    "user-id",
+			Name:     "test-model",
+			Provider: "LOCAL",
+			Versions: []*api.ModelVersion{{UUID: "version-uuid", Hash: "hash-123"}},
+		}}, nil
+	}
+}
+
+func TestRunAddModelDeleteAfterUploadRemovesOnlyVerifiedFiles(t *testing.T) {
+	resetAddModelGlobals(t)
+	stubAddModelUploadSeams(t)
+
+	modelDir := t.TempDir()
+	weightsPath := filepath.Join(modelDir, "weights.bin")
+	configPath := filepath.Join(modelDir, "config.json")
+	if err := os.WriteFile(weightsPath, []byte("weights"), 0600); err != nil {
+		t.Fatalf("write weights file: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("config"), 0600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	addModelOwner = "user-id"
+	addModelName = "test-model"
+	addModelDirectoryPath = modelDir
+	addModelWaitForHash = true
+	addModelDeleteAfterUpload = true
+	addModelVerbose = true
+
+	cmd := newTestAddModelCommand()
+	stdout, stderr := captureStdStreams(t, func() {
+		if err := runAddModel(cmd, nil); err != nil {
+			t.Fatalf("runAddModel: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(weightsPath); !os.IsNotExist(err) {
+		t.Fatalf("expected weights.bin to be deleted after verified upload, stat err: %v", err)
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("expected config.json to be deleted after verified upload, stat err: %v", err)
+	}
+
+	if !strings.Contains(stderr, "deleted 2 verified model file(s)") {
+		t.Fatalf("expected deletion confirmation on stderr, got %q", stderr)
+	}
+
+	var output modelAddOutput
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout)
+	}
+	if output.DeletedModelFiles != 2 {
+		t.Fatalf("expected 2 deleted files reported, got %d", output.DeletedModelFiles)
+	}
+	if output.DeletedModelFilesBytes != int64(len("weights")+len("config")) {
+		t.Fatalf("expected deleted bytes to match file sizes, got %d", output.DeletedModelFilesBytes)
+	}
+}
+
+func TestRunAddModelDeleteAfterUploadLeavesFilesWhenHashConfirmationFails(t *testing.T) {
+	resetAddModelGlobals(t)
+	stubAddModelUploadSeams(t)
+
+	// leave sleepModelHashPoll as the real waitModelHashPoll: with
+	// addModelHashTimeout set to 1ns below, the context is already expired by
+	// the time the poll loop calls it, so its ctx.Done() case fires
+	// immediately and the loop reports a timeout on its next check — the
+	// hash lookup below never needs to return a real hash.
+	modelDir := t.TempDir()
+	weightsPath := filepath.Join(modelDir, "weights.bin")
+	if err := os.WriteFile(weightsPath, []byte("weights"), 0600); err != nil {
+		t.Fatalf("write weights file: %v", err)
+	}
+
+	getModelsForAdd = func(input *api.GetModelsInput) ([]*api.Model, error) {
+		// hash never shows up
+		return []*api.Model{{
+			ID:       "model-id",
+			Owner:    "user-id",
+			Name:     "test-model",
+			Provider: "LOCAL",
+			Versions: []*api.ModelVersion{{UUID: "version-uuid", Hash: ""}},
+		}}, nil
+	}
+
+	addModelOwner = "user-id"
+	addModelName = "test-model"
+	addModelDirectoryPath = modelDir
+	addModelWaitForHash = true
+	addModelDeleteAfterUpload = true
+	addModelHashTimeout = 1 // nanoseconds; context.WithTimeout expires immediately
+
+	cmd := newTestAddModelCommand()
+	var runErr error
+	captureStdStreams(t, func() {
+		runErr = runAddModel(cmd, nil)
+	})
+
+	if runErr == nil {
+		t.Fatal("expected non-zero error when hash confirmation fails")
+	}
+	if !strings.Contains(runErr.Error(), "timed out waiting for the model hash") {
+		t.Fatalf("expected timeout error, got %v", runErr)
+	}
+
+	if _, err := os.Stat(weightsPath); err != nil {
+		t.Fatalf("expected weights.bin to remain on disk when hash was never confirmed, stat err: %v", err)
+	}
+}
+
+func TestDeleteVerifiedModelFilesReturnsNonZeroOnPartialFailure(t *testing.T) {
+	oldRemove := removeModelFile
+	t.Cleanup(func() { removeModelFile = oldRemove })
+
+	var removed []string
+	removeModelFile = func(path string) error {
+		if strings.HasSuffix(path, "b.bin") {
+			return errors.New("permission denied")
+		}
+		removed = append(removed, path)
+		return nil
+	}
+
+	files := []modelFile{
+		{AbsolutePath: "/tmp/model/a.bin", RelativePath: "a.bin", Size: 10},
+		{AbsolutePath: "/tmp/model/b.bin", RelativePath: "b.bin", Size: 20},
+		{AbsolutePath: "/tmp/model/c.bin", RelativePath: "c.bin", Size: 30},
+	}
+
+	deletedCount, deletedBytes, err := deleteVerifiedModelFiles(files)
+
+	if err == nil {
+		t.Fatal("expected error when one of the files fails to delete")
+	}
+	if !strings.Contains(err.Error(), "failed to delete 1 of 3 model file(s)") {
+		t.Fatalf("expected partial-failure summary in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "b.bin: permission denied") {
+		t.Fatalf("expected the specific failing file in the error, got %v", err)
+	}
+	if deletedCount != 2 {
+		t.Fatalf("expected 2 successfully deleted files reported even on partial failure, got %d", deletedCount)
+	}
+	if deletedBytes != 40 {
+		t.Fatalf("expected 40 deleted bytes (a.bin + c.bin), got %d", deletedBytes)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("expected exactly a.bin and c.bin to be removed, got %#v", removed)
+	}
+}
+
+func TestDeleteVerifiedModelFilesSucceedsWhenAllRemoved(t *testing.T) {
+	oldRemove := removeModelFile
+	t.Cleanup(func() { removeModelFile = oldRemove })
+
+	var removed []string
+	removeModelFile = func(path string) error {
+		removed = append(removed, path)
+		return nil
+	}
+
+	files := []modelFile{
+		{AbsolutePath: "/tmp/model/a.bin", RelativePath: "a.bin", Size: 5},
+	}
+
+	deletedCount, deletedBytes, err := deleteVerifiedModelFiles(files)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if deletedCount != 1 || deletedBytes != 5 {
+		t.Fatalf("expected 1 file / 5 bytes deleted, got %d/%d", deletedCount, deletedBytes)
+	}
+	if len(removed) != 1 || removed[0] != "/tmp/model/a.bin" {
+		t.Fatalf("expected removeModelFile called with absolute path, got %#v", removed)
+	}
+}

--- a/cmd/model/addModelToRepo.go
+++ b/cmd/model/addModelToRepo.go
@@ -42,6 +42,7 @@ var (
 	addModelWaitForHash         bool
 	addModelHashTimeout         time.Duration
 	addModelVerbose             bool
+	addModelDeleteAfterUpload   bool
 )
 
 const (
@@ -108,12 +109,14 @@ type uploadedModelFile struct {
 }
 
 type modelAddOutput struct {
-	Model          *api.Model           `json:"model,omitempty"`
-	Upload         *api.ModelRepoUpload `json:"upload,omitempty"`
-	UploadedFiles  []uploadedModelFile  `json:"uploadedFiles,omitempty"`
-	ModelSizeBytes *int64               `json:"modelSizeBytes,omitempty"`
-	ModelHash      string               `json:"modelHash,omitempty"`
-	ModelURL       string               `json:"modelUrl,omitempty"`
+	Model                  *api.Model           `json:"model,omitempty"`
+	Upload                 *api.ModelRepoUpload `json:"upload,omitempty"`
+	UploadedFiles          []uploadedModelFile  `json:"uploadedFiles,omitempty"`
+	ModelSizeBytes         *int64               `json:"modelSizeBytes,omitempty"`
+	ModelHash              string               `json:"modelHash,omitempty"`
+	ModelURL               string               `json:"modelUrl,omitempty"`
+	DeletedModelFiles      int                  `json:"deletedModelFiles,omitempty"`
+	DeletedModelFilesBytes int64                `json:"deletedModelFilesBytes,omitempty"`
 }
 
 type compactModelAddOutput struct {
@@ -153,6 +156,7 @@ var (
 	completeModelUploadFile = completeModelUploadWithProgress
 	getModelsForAdd         = api.GetModels
 	sleepModelHashPoll      = waitModelHashPoll
+	removeModelFile         = os.Remove
 )
 
 var addCmd = &cobra.Command{
@@ -161,7 +165,10 @@ var addCmd = &cobra.Command{
 	Short: "add a model",
 	Long:  "add a model to the runpod model repository",
 	Example: `  # --name is the destination; --huggingface-model is the source
-  runpodctl model add --name tiny-llm --huggingface-model arnir0/Tiny-LLM`,
+  runpodctl model add --name tiny-llm --huggingface-model arnir0/Tiny-LLM
+
+  # upload local files, then delete them once the model version hash is confirmed
+  runpodctl model add --name my-model --model-path ./my-model-dir --wait-for-hash --delete-my-model-files-after-upload`,
 	RunE: runAddModel,
 }
 
@@ -198,6 +205,7 @@ func bindAddModelFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&addModelWaitForHash, "wait-for-hash", false, "wait for completed model-path uploads to be hashed")
 	cmd.Flags().DurationVar(&addModelHashTimeout, "hash-timeout", modelHashWaitTimeout, "maximum duration to wait for --wait-for-hash (0 disables timeout)")
 	cmd.Flags().BoolVarP(&addModelVerbose, "verbose", "v", false, "include upload details in wait-for-hash output")
+	cmd.Flags().BoolVar(&addModelDeleteAfterUpload, "delete-my-model-files-after-upload", false, "delete the uploaded --model-path files once the model version hash is confirmed (requires --wait-for-hash)")
 }
 
 func isHuggingFaceMirror() bool {
@@ -342,6 +350,20 @@ func runAddModel(cmd *cobra.Command, args []string) error {
 			result.ModelHash = ready.ModelHash
 			result.ModelURL = ready.ModelURL
 			printModelReadyURL(ready.ModelURL)
+
+			if addModelDeleteAfterUpload {
+				deletedCount, deletedBytes, deleteErr := deleteVerifiedModelFiles(modelFiles)
+				result.DeletedModelFiles = deletedCount
+				result.DeletedModelFilesBytes = deletedBytes
+				if deleteErr != nil {
+					// the upload and hash are already confirmed above, so this is
+					// reported as its own failure rather than folded into a generic
+					// upload error: the model is fully usable, only local cleanup
+					// did not complete.
+					return deleteErr
+				}
+			}
+
 			if !addModelVerbose {
 				return printCompactModelAddOutput(cmd, model)
 			}
@@ -378,6 +400,18 @@ func runAddModel(cmd *cobra.Command, args []string) error {
 }
 
 func validateAddModelFlags() error {
+	if addModelDeleteAfterUpload {
+		// checked before the huggingface-model conflict below so a user who
+		// combines all three flags gets the more specific, more actionable
+		// error first instead of the generic "cannot be combined" message.
+		if addModelDirectoryPath == "" {
+			return fmt.Errorf("--delete-my-model-files-after-upload requires --model-path")
+		}
+		if !addModelWaitForHash {
+			return fmt.Errorf("--delete-my-model-files-after-upload requires --wait-for-hash: files are only deleted once the model version hash is confirmed server-side")
+		}
+	}
+
 	if !isHuggingFaceMirror() {
 		return nil
 	}
@@ -457,6 +491,37 @@ func totalModelFileSize(files []modelFile) int64 {
 		total += file.Size
 	}
 	return total
+}
+
+// deleteVerifiedModelFiles removes the local --model-path files backing
+// --delete-my-model-files-after-upload. Callers must only invoke this after
+// every file in `files` has both (a) completed its multipart upload
+// (uploadModelFiles returned without error) and (b) had its model version
+// hash confirmed server-side (waitForUploadedModelHash returned without
+// error) — this function does not itself re-check either condition. It never
+// deletes anything else in --model-path: only the exact absolute paths that
+// were part of this run's verified upload, never a directory-wide wipe.
+func deleteVerifiedModelFiles(files []modelFile) (deletedCount int, deletedBytes int64, err error) {
+	var failures []string
+
+	for _, file := range files {
+		if removeErr := removeModelFile(file.AbsolutePath); removeErr != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", file.RelativePath, removeErr))
+			continue
+		}
+		deletedCount++
+		deletedBytes += file.Size
+	}
+
+	if deletedCount > 0 {
+		fmt.Fprintf(os.Stderr, "deleted %d verified model file(s) (%d bytes) from %s\n", deletedCount, deletedBytes, addModelDirectoryPath)
+	}
+
+	if len(failures) > 0 {
+		return deletedCount, deletedBytes, fmt.Errorf("upload and hash are confirmed, but failed to delete %d of %d model file(s) from %s: %s", len(failures), len(files), addModelDirectoryPath, strings.Join(failures, "; "))
+	}
+
+	return deletedCount, deletedBytes, nil
 }
 
 func stderrIsTerminal() bool {

--- a/cmd/model/addModelToRepo_timeout_test.go
+++ b/cmd/model/addModelToRepo_timeout_test.go
@@ -961,6 +961,7 @@ func resetAddModelGlobals(t *testing.T) {
 	oldWaitForHash := addModelWaitForHash
 	oldHashTimeout := addModelHashTimeout
 	oldVerbose := addModelVerbose
+	oldDeleteAfterUpload := addModelDeleteAfterUpload
 	t.Cleanup(func() {
 		addModelOwner = oldOwner
 		addModelName = oldName
@@ -978,6 +979,7 @@ func resetAddModelGlobals(t *testing.T) {
 		addModelWaitForHash = oldWaitForHash
 		addModelHashTimeout = oldHashTimeout
 		addModelVerbose = oldVerbose
+		addModelDeleteAfterUpload = oldDeleteAfterUpload
 	})
 
 	addModelOwner = ""
@@ -996,4 +998,5 @@ func resetAddModelGlobals(t *testing.T) {
 	addModelWaitForHash = false
 	addModelHashTimeout = modelHashWaitTimeout
 	addModelVerbose = false
+	addModelDeleteAfterUpload = false
 }

--- a/cmd/model/getModels_test.go
+++ b/cmd/model/getModels_test.go
@@ -76,6 +76,9 @@ func TestModelCommandFlags(t *testing.T) {
 	if addCmd.Flags().Lookup("verbose") == nil {
 		t.Fatal("expected model add --verbose flag")
 	}
+	if addCmd.Flags().Lookup("delete-my-model-files-after-upload") == nil {
+		t.Fatal("expected model add --delete-my-model-files-after-upload flag")
+	}
 	if addCmd.Flags().Lookup("version-status") != nil {
 		t.Fatal("did not expect model add --version-status flag")
 	}

--- a/docs/runpodctl_model_add.md
+++ b/docs/runpodctl_model_add.md
@@ -15,28 +15,32 @@ runpodctl model add [flags]
 ```
   # --name is the destination; --huggingface-model is the source
   runpodctl model add --name tiny-llm --huggingface-model arnir0/Tiny-LLM
+
+  # upload local files, then delete them once the model version hash is confirmed
+  runpodctl model add --name my-model --model-path ./my-model-dir --wait-for-hash --delete-my-model-files-after-upload
 ```
 
 ### Options
 
 ```
-      --content-type string           upload content type
-      --create-upload                 create an upload session
-      --credential-reference string   credential reference (if required)
-      --credential-type string        credential type (if required)
-      --file-name string              file name for upload
-      --file-size string              file size in bytes
-      --hash-timeout duration         maximum duration to wait for --wait-for-hash (0 disables timeout) (default 30m0s)
-  -h, --help                          help for add
-      --huggingface-model string      hugging face model to mirror (owner/repo)
-      --metadata stringToString       metadata key=value pairs (default [])
-      --model-path string             directory containing model files to upload
-      --model-status string           initial model status
-      --name string                   model name
-      --owner string                  model owner namespace (user or team owner id)
-      --part-size string              multipart upload part size in bytes
-  -v, --verbose                       include upload details in wait-for-hash output
-      --wait-for-hash                 wait for completed model-path uploads to be hashed
+      --content-type string                  upload content type
+      --create-upload                        create an upload session
+      --credential-reference string          credential reference (if required)
+      --credential-type string               credential type (if required)
+      --delete-my-model-files-after-upload   delete the uploaded --model-path files once the model version hash is confirmed (requires --wait-for-hash)
+      --file-name string                     file name for upload
+      --file-size string                     file size in bytes
+      --hash-timeout duration                maximum duration to wait for --wait-for-hash (0 disables timeout) (default 30m0s)
+  -h, --help                                 help for add
+      --huggingface-model string             hugging face model to mirror (owner/repo)
+      --metadata stringToString              metadata key=value pairs (default [])
+      --model-path string                    directory containing model files to upload
+      --model-status string                  initial model status
+      --name string                          model name
+      --owner string                         model owner namespace (user or team owner id)
+      --part-size string                     multipart upload part size in bytes
+  -v, --verbose                              include upload details in wait-for-hash output
+      --wait-for-hash                        wait for completed model-path uploads to be hashed
 ```
 
 ### Options inherited from parent commands
@@ -48,3 +52,4 @@ runpodctl model add [flags]
 ### SEE ALSO
 
 * [runpodctl model](runpodctl_model.md)	 - manage model repository
+


### PR DESCRIPTION
Fixes STO-446.

`model add --model-path` uploads whatever files are currently in the directory, with no tracking of what belonged to a previous version. Reusing the same local directory across model versions silently uploads a contaminated mixture of old and new files.

## Fix

New opt-in flag: `--delete-my-model-files-after-upload`.

- Requires `--model-path` and `--wait-for-hash` — errors immediately (before any upload) if either is missing.
- Deletes only the exact files uploaded by this run, and only after the model version hash is confirmed server-side. Never a blanket directory wipe.
- If hash confirmation or any file deletion fails, the command exits non-zero and leaves files in place — no silent partial success.
- Adds `deletedModelFiles`/`deletedModelFilesBytes` to JSON output.

## Testing

- New unit tests covering flag validation, the happy path (verified deletion + output), and both failure modes (hash-confirmation failure leaves files untouched; partial delete failure reports non-zero with the specific failing file).
- Full existing test suite passes.
- Validated end-to-end against a local RIAB stack (real GraphQL + S3-backed upload + hasher pipeline, not mocks):
  - Reproduced the original contamination bug: uploading model B into a directory still holding model A's `config.json` silently included it — confirmed by downloading the file and seeing model A's content.
  - Confirmed the fix leaves the directory clean after a verified upload.
  - Confirmed the hash-timeout failure path leaves files untouched with a non-zero exit.
  - **Round-trip integrity check:** uploaded a 4-file model (including a nested subdirectory) with the new flag, captured SHA-256 hashes of the originals before upload, let the flag delete the local copies, then re-downloaded all 4 files through mProxy's presigned S3 URLs and diffed hashes. All 4 files were byte-identical to the originals — confirms the server-side stored blobs are correct before the local copies are removed, not just trusted based on the upload response.

## Follow-up (not in this PR)

The `runpodctl` skill and vendored `command-surface.json` in `runpod/runpod-plugins-official` are both tied to released versions — will update those once this ships in a release.
