### PR TITLE
feat: add serverless model-status command (STO-359)

### DIFF
--- a/api/modelStatus.go
+++ b/api/modelStatus.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// PodModelVersion is one model version a pod (worker) requires, with the
+// machine-level assignment diagnostics reported by the host (STO-359/STO-529).
+// FailurePhase/FailureReason are only populated when Status is "FAILED";
+// MountPath is populated whenever the host has reported it, on any status.
+// All four diagnostics fields are nil when no assignment row exists yet --
+// i.e. the model has not been tracked on this worker's machine.
+type PodModelVersion struct {
+	ModelVersionUUID string  `json:"modelVersionUuid"`
+	ModelVersionHash string  `json:"modelVersionHash"`
+	Status           *string `json:"machineAssignmentStatus"`
+	FailurePhase     *string `json:"failurePhase"`
+	FailureReason    *string `json:"failureReason"`
+	MountPath        *string `json:"mountPath"`
+}
+
+// GetEndpointModelReferences returns the model references configured on an
+// endpoint (e.g. "https://huggingface.co/org/model:revision" or a Model Repo
+// reference) -- REST omits this field entirely, so it must go through
+// GraphQL. Returns an empty slice, not an error, for an endpoint with no
+// configured model references.
+func GetEndpointModelReferences(endpointID string) ([]string, error) {
+	id := strings.TrimSpace(endpointID)
+	if id == "" {
+		return nil, fmt.Errorf("endpointID cannot be empty")
+	}
+
+	gqlInput := Input{
+		Query: `
+                query EndpointModelReferences($id: String!) {
+                        myself {
+                                endpoint(id: $id) {
+                                        modelReferences
+                                }
+                        }
+                }
+                `,
+		Variables: map[string]interface{}{"id": id},
+	}
+
+	res, err := Query(gqlInput)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	rawData, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("statuscode %d: %s", res.StatusCode, string(rawData))
+	}
+
+	var data struct {
+		Data *struct {
+			Myself *struct {
+				Endpoint *struct {
+					ModelReferences []string `json:"modelReferences"`
+				} `json:"endpoint"`
+			} `json:"myself"`
+		} `json:"data"`
+		Errors []*GraphQLError `json:"errors"`
+	}
+	if err = json.Unmarshal(rawData, &data); err != nil {
+		return nil, err
+	}
+	if len(data.Errors) > 0 {
+		return nil, errors.New(data.Errors[0].Message)
+	}
+	if data.Data == nil || data.Data.Myself == nil || data.Data.Myself.Endpoint == nil {
+		return nil, fmt.Errorf("endpoint %s not found", id)
+	}
+
+	return data.Data.Myself.Endpoint.ModelReferences, nil
+}
+
+// GetPodModelVersions returns the model versions a pod (worker) requires,
+// each with the machine-level assignment diagnostics reported by the host.
+// Returns an empty slice, not an error, for a pod with no model dependency.
+func GetPodModelVersions(podID string) ([]*PodModelVersion, error) {
+	id := strings.TrimSpace(podID)
+	if id == "" {
+		return nil, fmt.Errorf("podID cannot be empty")
+	}
+
+	gqlInput := Input{
+		Query: `
+                query PodModelVersions($podId: String!) {
+                        pod(input: { podId: $podId }) {
+                                modelVersions {
+                                        modelVersionUuid
+                                        modelVersionHash
+                                        machineAssignmentStatus
+                                        failurePhase
+                                        failureReason
+                                        mountPath
+                                }
+                        }
+                }
+                `,
+		Variables: map[string]interface{}{"podId": id},
+	}
+
+	res, err := Query(gqlInput)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	rawData, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("statuscode %d: %s", res.StatusCode, string(rawData))
+	}
+
+	var data struct {
+		Data *struct {
+			Pod *struct {
+				ModelVersions []*PodModelVersion `json:"modelVersions"`
+			} `json:"pod"`
+		} `json:"data"`
+		Errors []*GraphQLError `json:"errors"`
+	}
+	if err = json.Unmarshal(rawData, &data); err != nil {
+		return nil, err
+	}
+	if len(data.Errors) > 0 {
+		return nil, errors.New(data.Errors[0].Message)
+	}
+	if data.Data == nil || data.Data.Pod == nil {
+		return nil, fmt.Errorf("pod %s not found", id)
+	}
+
+	return data.Data.Pod.ModelVersions, nil
+}

--- a/api/modelStatus_test.go
+++ b/api/modelStatus_test.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestGetEndpointModelReferencesReturnsConfiguredReferences(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	var gotID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input Input
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if id, ok := input.Variables["id"].(string); ok {
+			gotID = id
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"myself": map[string]interface{}{
+					"endpoint": map[string]interface{}{
+						"modelReferences": []string{"https://huggingface.co/org/model:main"},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", server.URL)
+
+	refs, err := GetEndpointModelReferences("endpoint-1")
+	if err != nil {
+		t.Fatalf("GetEndpointModelReferences returned error: %v", err)
+	}
+	if gotID != "endpoint-1" {
+		t.Fatalf("expected id variable endpoint-1, got %q", gotID)
+	}
+	if len(refs) != 1 || refs[0] != "https://huggingface.co/org/model:main" {
+		t.Fatalf("unexpected references: %#v", refs)
+	}
+}
+
+func TestGetEndpointModelReferencesEmptyIDIsRejectedLocally(t *testing.T) {
+	if _, err := GetEndpointModelReferences("  "); err == nil {
+		t.Fatal("expected an error for an empty endpoint id")
+	}
+}
+
+func TestGetEndpointModelReferencesNotFound(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"myself": map[string]interface{}{
+					"endpoint": nil,
+				},
+			},
+		})
+	}))
+	defer server.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", server.URL)
+
+	if _, err := GetEndpointModelReferences("missing-endpoint"); err == nil {
+		t.Fatal("expected an error when the endpoint is not found")
+	}
+}
+
+func TestGetPodModelVersionsReturnsDiagnostics(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	var gotPodID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input Input
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if id, ok := input.Variables["podId"].(string); ok {
+			gotPodID = id
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"pod": map[string]interface{}{
+					"modelVersions": []map[string]interface{}{
+						{
+							"modelVersionUuid":        "uuid-a",
+							"modelVersionHash":        "hash-a",
+							"machineAssignmentStatus": "FAILED",
+							"failurePhase":            "download_failed",
+							"failureReason":           "2 of 5 files failed to download",
+							"mountPath":               "/runpod/model-store/huggingface/org/model/hash-a",
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", server.URL)
+
+	versions, err := GetPodModelVersions("worker-1")
+	if err != nil {
+		t.Fatalf("GetPodModelVersions returned error: %v", err)
+	}
+	if gotPodID != "worker-1" {
+		t.Fatalf("expected podId variable worker-1, got %q", gotPodID)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("expected 1 model version, got %d", len(versions))
+	}
+	v := versions[0]
+	if v.ModelVersionHash != "hash-a" {
+		t.Errorf("modelVersionHash = %q, want hash-a", v.ModelVersionHash)
+	}
+	if v.Status == nil || *v.Status != "FAILED" {
+		t.Errorf("status = %v, want FAILED", v.Status)
+	}
+	if v.FailurePhase == nil || *v.FailurePhase != "download_failed" {
+		t.Errorf("failurePhase = %v, want download_failed", v.FailurePhase)
+	}
+	if v.FailureReason == nil || *v.FailureReason != "2 of 5 files failed to download" {
+		t.Errorf("failureReason = %v, want a non-empty reason", v.FailureReason)
+	}
+	if v.MountPath == nil || *v.MountPath != "/runpod/model-store/huggingface/org/model/hash-a" {
+		t.Errorf("mountPath = %v, want the expected mount path", v.MountPath)
+	}
+}
+
+func TestGetPodModelVersionsEmptyForNoModelDependency(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"pod": map[string]interface{}{
+					"modelVersions": []map[string]interface{}{},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", server.URL)
+
+	versions, err := GetPodModelVersions("worker-no-model")
+	if err != nil {
+		t.Fatalf("GetPodModelVersions returned error: %v", err)
+	}
+	if len(versions) != 0 {
+		t.Fatalf("expected no model versions, got %#v", versions)
+	}
+}
+
+func TestGetPodModelVersionsEmptyIDIsRejectedLocally(t *testing.T) {
+	if _, err := GetPodModelVersions(""); err == nil {
+		t.Fatal("expected an error for an empty pod id")
+	}
+}
+
+func TestGetPodModelVersionsGraphQLErrorSurfaces(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	t.Setenv("RUNPOD_API_KEY", "test-key")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"errors": []map[string]interface{}{{"message": "pod not found"}},
+		})
+	}))
+	defer server.Close()
+	t.Setenv("RUNPOD_GRAPHQL_URL", server.URL)
+
+	_, err := GetPodModelVersions("gone")
+	if err == nil {
+		t.Fatal("expected an error to surface from the graphql response")
+	}
+	if err.Error() != "pod not found" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/serverless/modelStatus.go
+++ b/cmd/serverless/modelStatus.go
@@ -1,0 +1,122 @@
+package serverless
+
+import (
+	"fmt"
+
+	"github.com/runpod/runpodctl/api"
+	internalapi "github.com/runpod/runpodctl/internal/api"
+	"github.com/runpod/runpodctl/internal/output"
+
+	"github.com/spf13/cobra"
+)
+
+var modelStatusCmd = &cobra.Command{
+	Use:   "model-status <endpoint-id>",
+	Short: "diagnose model repo assignment and mount status for an endpoint's workers",
+	Long: `show a serverless endpoint's configured model references and, for each
+worker, the resolved model version hash, machine assignment status, failure
+phase and reason (if any), and expected mount path.
+
+this exists to let you diagnose why a model repo-backed endpoint is stuck
+loading or failing to mount a model, without ssh access or internal host logs.
+
+a status of FAILED carries a failurePhase (download_failed, mount_failed,
+startup_failed, or cuda_failed) and a failureReason summarizing what went
+wrong. for the full free-text detail behind that summary, follow up with
+` + "`runpodctl serverless logs <endpoint-id> --source system`" + `.
+
+not covered here: download/mount progress percentage, and the container's
+effective MODEL_NAME/MODEL_REVISION environment variables -- neither is
+exposed by any api today.`,
+	Example: `  # every worker's model assignment status for an endpoint
+  runpodctl serverless model-status abc123`,
+	Args: cobra.ExactArgs(1),
+	RunE: runModelStatus,
+}
+
+func init() {
+	Cmd.AddCommand(modelStatusCmd)
+}
+
+// WorkerModelDiagnostics is one worker's model-repo diagnostics: its current
+// status from the v2 worker listing, plus the model versions it requires with
+// their machine-level assignment diagnostics. Error is set instead of
+// ModelVersions when the per-worker lookup failed, so one bad worker cannot
+// blank out every other worker's diagnostics in the same response.
+type WorkerModelDiagnostics struct {
+	WorkerID      string                 `json:"workerId"`
+	WorkerStatus  string                 `json:"workerStatus"`
+	ModelVersions []*api.PodModelVersion `json:"modelVersions,omitempty"`
+	Error         string                 `json:"error,omitempty"`
+}
+
+// ModelStatusResult is the output of `runpodctl serverless model-status`.
+type ModelStatusResult struct {
+	EndpointID      string                   `json:"endpointId"`
+	ModelReferences []string                 `json:"modelReferences"`
+	Workers         []WorkerModelDiagnostics `json:"workers"`
+}
+
+func runModelStatus(cmd *cobra.Command, args []string) error {
+	result, err := buildModelStatusResult(args[0])
+	if err != nil {
+		return err
+	}
+
+	format := output.ParseFormat(cmd.Flag("output").Value.String())
+	return output.Print(result, &output.Config{Format: format})
+}
+
+// buildModelStatusResult assembles the model-status diagnostics for an
+// endpoint: its configured model references, plus each current worker's
+// resolved model versions and machine assignment diagnostics. Exported for
+// unit testing (lowercase, package-local -- same pattern as resolveLogTargets
+// in logs.go).
+func buildModelStatusResult(endpointID string) (*ModelStatusResult, error) {
+	modelReferences, err := api.GetEndpointModelReferences(endpointID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get model references for endpoint %s: %w", endpointID, err)
+	}
+
+	v2Client, err := internalapi.NewV2Client()
+	if err != nil {
+		return nil, err
+	}
+	workersResp, err := v2Client.ListEndpointWorkersWithTimeout(endpointID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workers for endpoint %s: %w", endpointID, err)
+	}
+
+	result := &ModelStatusResult{
+		EndpointID:      endpointID,
+		ModelReferences: modelReferences,
+		Workers:         make([]WorkerModelDiagnostics, 0, len(workersResp.Workers)),
+	}
+
+	for _, worker := range workersResp.Workers {
+		if worker.ID == "" {
+			// Cannot be addressed by a pod-scoped query; same guard as
+			// workerTargets in logs.go.
+			continue
+		}
+
+		diagnostics := WorkerModelDiagnostics{
+			WorkerID:     worker.ID,
+			WorkerStatus: worker.Status,
+		}
+
+		versions, err := api.GetPodModelVersions(worker.ID)
+		if err != nil {
+			// One worker's lookup failing (e.g. it terminated between the
+			// list call and this one) should not blank out every other
+			// worker's diagnostics -- report it inline instead.
+			diagnostics.Error = err.Error()
+		} else {
+			diagnostics.ModelVersions = versions
+		}
+
+		result.Workers = append(result.Workers, diagnostics)
+	}
+
+	return result, nil
+}

--- a/cmd/serverless/modelStatus_test.go
+++ b/cmd/serverless/modelStatus_test.go
@@ -1,0 +1,222 @@
+package serverless
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/runpod/runpodctl/api"
+	"github.com/runpod/runpodctl/internal/configenv"
+	"github.com/spf13/viper"
+)
+
+// withModelStatusServer runs one test server that answers both the GraphQL
+// endpoint (api.GetEndpointModelReferences, api.GetPodModelVersions) and the
+// v2 REST worker listing (internalapi.ListEndpointWorkersWithTimeout), routed
+// by method/path -- buildModelStatusResult calls both in the same request.
+func withModelStatusServer(t *testing.T, graphqlHandler http.HandlerFunc, restHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			graphqlHandler(w, r)
+			return
+		}
+		restHandler(w, r)
+	}))
+	t.Setenv(configenv.GraphQLURLEnv, server.URL)
+	t.Setenv(configenv.RESTV2URLEnv, server.URL)
+	t.Setenv(configenv.APIKeyEnv, "test-key")
+	previousTimeout := viper.Get("timeout")
+	viper.Set("timeout", 0)
+	t.Cleanup(func() { viper.Set("timeout", previousTimeout) })
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestModelStatusCmdRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range Cmd.Commands() {
+		if cmd.Use == "model-status <endpoint-id>" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("serverless model-status is not registered on the serverless command")
+	}
+}
+
+func TestBuildModelStatusResultAssemblesReferencesAndPerWorkerDiagnostics(t *testing.T) {
+	withModelStatusServer(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			var input api.Input
+			if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+				t.Fatalf("decode graphql request: %v", err)
+			}
+			switch {
+			case strings.Contains(input.Query, "EndpointModelReferences"):
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"data": map[string]interface{}{
+						"myself": map[string]interface{}{
+							"endpoint": map[string]interface{}{
+								"modelReferences": []string{"https://huggingface.co/org/model:main"},
+							},
+						},
+					},
+				})
+			case strings.Contains(input.Query, "PodModelVersions"):
+				podID, _ := input.Variables["podId"].(string)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"data": map[string]interface{}{
+						"pod": map[string]interface{}{
+							"modelVersions": []map[string]interface{}{
+								{
+									"modelVersionUuid":        "uuid-" + podID,
+									"modelVersionHash":        "hash-" + podID,
+									"machineAssignmentStatus": "DEPLOYED",
+									"failurePhase":            nil,
+									"failureReason":           nil,
+									"mountPath":               "/runpod/model-store/huggingface/org/model/hash-" + podID,
+								},
+							},
+						},
+					},
+				})
+			default:
+				t.Fatalf("unexpected graphql query: %s", input.Query)
+			}
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/serverless/ep1/workers" {
+				t.Fatalf("unexpected rest path %q", r.URL.Path)
+			}
+			fmt.Fprint(w, `{"workers":[{"id":"w1","status":"RUNNING"},{"id":"w2","status":"IDLE"}]}`)
+		},
+	)
+
+	result, err := buildModelStatusResult("ep1")
+	if err != nil {
+		t.Fatalf("buildModelStatusResult returned error: %v", err)
+	}
+
+	if result.EndpointID != "ep1" {
+		t.Errorf("endpointId = %q, want ep1", result.EndpointID)
+	}
+	if len(result.ModelReferences) != 1 || result.ModelReferences[0] != "https://huggingface.co/org/model:main" {
+		t.Fatalf("unexpected model references: %#v", result.ModelReferences)
+	}
+	if len(result.Workers) != 2 {
+		t.Fatalf("workers = %d, want 2", len(result.Workers))
+	}
+	for i, wantID := range []string{"w1", "w2"} {
+		worker := result.Workers[i]
+		if worker.WorkerID != wantID {
+			t.Errorf("worker %d id = %q, want %q", i, worker.WorkerID, wantID)
+		}
+		if worker.Error != "" {
+			t.Errorf("worker %d unexpected error: %s", i, worker.Error)
+		}
+		if len(worker.ModelVersions) != 1 {
+			t.Fatalf("worker %d modelVersions = %d, want 1", i, len(worker.ModelVersions))
+		}
+		if worker.ModelVersions[0].ModelVersionHash != "hash-"+wantID {
+			t.Errorf("worker %d hash = %q", i, worker.ModelVersions[0].ModelVersionHash)
+		}
+	}
+}
+
+// A worker whose model-version lookup fails must not blank out the other
+// workers' diagnostics in the same response -- the error is reported inline
+// on that one worker instead.
+func TestBuildModelStatusResultOneWorkerFailureDoesNotBlankOthers(t *testing.T) {
+	withModelStatusServer(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			var input api.Input
+			if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+				t.Fatalf("decode graphql request: %v", err)
+			}
+			switch {
+			case strings.Contains(input.Query, "EndpointModelReferences"):
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"data": map[string]interface{}{
+						"myself": map[string]interface{}{
+							"endpoint": map[string]interface{}{"modelReferences": []string{}},
+						},
+					},
+				})
+			case strings.Contains(input.Query, "PodModelVersions"):
+				podID, _ := input.Variables["podId"].(string)
+				if podID == "w-bad" {
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"errors": []map[string]interface{}{{"message": "pod not found"}},
+					})
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"data": map[string]interface{}{
+						"pod": map[string]interface{}{"modelVersions": []map[string]interface{}{}},
+					},
+				})
+			}
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"workers":[{"id":"w-bad","status":"UNHEALTHY"},{"id":"w-good","status":"IDLE"}]}`)
+		},
+	)
+
+	result, err := buildModelStatusResult("ep1")
+	if err != nil {
+		t.Fatalf("buildModelStatusResult returned error: %v", err)
+	}
+	if len(result.Workers) != 2 {
+		t.Fatalf("workers = %d, want 2", len(result.Workers))
+	}
+	if result.Workers[0].Error == "" {
+		t.Error("expected the bad worker to carry an inline error")
+	}
+	if result.Workers[1].Error != "" {
+		t.Errorf("expected the good worker to be unaffected, got error %q", result.Workers[1].Error)
+	}
+}
+
+func TestBuildModelStatusResultSkipsWorkersWithoutIDs(t *testing.T) {
+	withModelStatusServer(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"myself": map[string]interface{}{
+						"endpoint": map[string]interface{}{"modelReferences": []string{}},
+					},
+				},
+			})
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"workers":[{"id":"","status":"UNKNOWN"}]}`)
+		},
+	)
+
+	result, err := buildModelStatusResult("ep1")
+	if err != nil {
+		t.Fatalf("buildModelStatusResult returned error: %v", err)
+	}
+	if len(result.Workers) != 0 {
+		t.Fatalf("expected workers without an id to be skipped, got %#v", result.Workers)
+	}
+}
+
+func TestBuildModelStatusResultPropagatesEndpointLookupError(t *testing.T) {
+	withModelStatusServer(t,
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		},
+		func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("must not list workers if the model-references lookup already failed")
+		},
+	)
+
+	if _, err := buildModelStatusResult("ep1"); err == nil {
+		t.Fatal("expected an error when the model-references lookup fails")
+	}
+}

--- a/docs/runpodctl_serverless.md
+++ b/docs/runpodctl_serverless.md
@@ -27,6 +27,7 @@ manage serverless endpoints on runpod
 * [runpodctl serverless health](runpodctl_serverless_health.md)	 - get endpoint health
 * [runpodctl serverless list](runpodctl_serverless_list.md)	 - list all endpoints
 * [runpodctl serverless logs](runpodctl_serverless_logs.md)	 - read a serverless endpoint's worker logs
+* [runpodctl serverless model-status](runpodctl_serverless_model-status.md)	 - diagnose model repo assignment and mount status for an endpoint's workers
 * [runpodctl serverless run](runpodctl_serverless_run.md)	 - invoke an endpoint and wait for the result
 * [runpodctl serverless status](runpodctl_serverless_status.md)	 - get the status of a serverless job
 * [runpodctl serverless update](runpodctl_serverless_update.md)	 - update an endpoint

--- a/docs/runpodctl_serverless_model-status.md
+++ b/docs/runpodctl_serverless_model-status.md
@@ -1,0 +1,49 @@
+## runpodctl serverless model-status
+
+diagnose model repo assignment and mount status for an endpoint's workers
+
+### Synopsis
+
+show a serverless endpoint's configured model references and, for each
+worker, the resolved model version hash, machine assignment status, failure
+phase and reason (if any), and expected mount path.
+
+this exists to let you diagnose why a model repo-backed endpoint is stuck
+loading or failing to mount a model, without ssh access or internal host logs.
+
+a status of FAILED carries a failurePhase (download_failed, mount_failed,
+startup_failed, or cuda_failed) and a failureReason summarizing what went
+wrong. for the full free-text detail behind that summary, follow up with
+`runpodctl serverless logs <endpoint-id> --source system`.
+
+not covered here: download/mount progress percentage, and the container's
+effective MODEL_NAME/MODEL_REVISION environment variables -- neither is
+exposed by any api today.
+
+```
+runpodctl serverless model-status <endpoint-id> [flags]
+```
+
+### Examples
+
+```
+  # every worker's model assignment status for an endpoint
+  runpodctl serverless model-status abc123
+```
+
+### Options
+
+```
+  -h, --help   help for model-status
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   output format (json, yaml) (default "json")
+```
+
+### SEE ALSO
+
+* [runpodctl serverless](runpodctl_serverless.md)	 - manage serverless endpoints
+


### PR DESCRIPTION
## STO-359: expose Model Repo assignment and mount diagnostics in runpodctl

- `runpodctl serverless model-status <endpoint-id>` shows an endpoint's configured model references and, per worker, the resolved model version hash, machine assignment status, failure phase and reason, and expected mount path — so a stuck or failing Model Repo-backed endpoint can be diagnosed without SSH or internal logs.
- Depends on runpod/RunPod#5783 (adds `failurePhase`/`failureReason`/`mountPath` to `Pod.modelVersions`), which depends on runpod/proxy#305 and runpod/host#2758 for the host→backend plumbing. This CLI change is inert until those land — the new fields just come back `null` until then.
- No existing command/API coverage touched; this is additive only.

## Related

- runpod/host#2758, runpod/proxy#305, runpod/RunPod#5783 — the rest of the STO-359 chain
- STO-529 (runpod/host#2757) — defines the `download_failed`/`mount_failed`/`startup_failed`/`cuda_failed` taxonomy `failurePhase` reports

## What

- `api.GetEndpointModelReferences` — `myself { endpoint(id) { modelReferences } }` via GraphQL, since REST omits `modelReferences` entirely (existing, documented gotcha).
- `api.GetPodModelVersions` — the ungated `Query.pod(input).modelVersions` field, now carrying `machineAssignmentStatus`, `failurePhase`, `failureReason`, `mountPath`.
- Workers resolved the same way `serverless logs` does: v2 REST `ListEndpointWorkersWithTimeout`, since the v1 REST worker expansion is unreliable (documented in this repo's AGENTS.md).
- One worker's lookup failing doesn't blank out the others — its error is reported inline on that worker (`WorkerModelDiagnostics.Error`) instead of failing the whole command.
- Regenerated `docs/runpodctl_serverless*.md` via `docs/docs-gen.go` (reverted unrelated pre-existing drift in other doc files that regeneration also touched).

Test plan:
- [x] `go test ./...`
- [ ] `go test -tags e2e ./e2e` — not run; no e2e coverage added for this command since it's inert until the backend fields exist (see dependency note above). Recommend an e2e pass once runpod/RunPod#5783 is deployed to dev.

## How I tested it

```
go build ./...
gofmt -l .
go vet ./...
go test ./...
```

All packages pass (`ok` across the full module), gofmt clean, vet clean. Added:
- `api/modelStatus_test.go` — `GetEndpointModelReferences`/`GetPodModelVersions` request shape, not-found, empty-id validation, and GraphQL error surfacing.
- `cmd/serverless/modelStatus_test.go` — command registration, full assembly (references + per-worker diagnostics from a combined GraphQL+REST test server), one-worker-failure isolation, skipping workers without an id, and endpoint-lookup-error propagation (asserting the REST worker list is never called if the GraphQL lookup already failed).